### PR TITLE
fix: missing hivemind entrypoint in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,6 +39,7 @@ def required(requirements_file):
                 if pkg.strip() and not pkg.startswith("#")]
 
 
+PLUGIN_ENTRY_POINT = 'hivemind-redis-db-plugin=hivemind_redis_database:RedisDB'
 
 setup(
     name='hivemind-redis-database',
@@ -48,6 +49,7 @@ setup(
     license='Apache-2.0',
     author='jarbasAi',
     install_requires=required("requirements.txt"),
+    entry_points={'hivemind.database': PLUGIN_ENTRY_POINT},
     author_email='jarbasai@mailfence.com',
     description='redis database plugin for hivemind-core'
 )


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added a plugin entry point for the Redis database, enabling easier integration with the Hivemind ecosystem.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->