### PR TITLE
Preserve client metadata

### DIFF
--- a/.github/workflows/build-tests.yml
+++ b/.github/workflows/build-tests.yml
@@ -13,3 +13,4 @@ jobs:
       python_versions: '["3.10", "3.11", "3.12", "3.13", "3.14"]'
       install_extras: 'test'
       test_path: 'tests'
+      pr_comment: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository }}

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -15,3 +15,4 @@ jobs:
       test_path: 'tests/'
       install_extras: ''
       min_coverage: 0
+      pr_comment: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository }}

--- a/.github/workflows/license_check.yml
+++ b/.github/workflows/license_check.yml
@@ -9,3 +9,5 @@ jobs:
   license_check:
     uses: OpenVoiceOS/gh-automations/.github/workflows/license-check.yml@dev
     secrets: inherit
+    with:
+      pr_comment: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,3 +12,4 @@ jobs:
     with:
       ruff: true
       pre_commit: false   # set true if .pre-commit-config.yaml exists
+      pr_comment: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository }}

--- a/.github/workflows/pip_audit.yml
+++ b/.github/workflows/pip_audit.yml
@@ -9,3 +9,5 @@ jobs:
   pip_audit:
     uses: OpenVoiceOS/gh-automations/.github/workflows/pip-audit.yml@dev
     secrets: inherit
+    with:
+      pr_comment: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository }}

--- a/.github/workflows/release-preview.yml
+++ b/.github/workflows/release-preview.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   release_preview:
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
     uses: OpenVoiceOS/gh-automations/.github/workflows/release-preview.yml@dev
     secrets: inherit
     with:

--- a/.github/workflows/repo-health.yml
+++ b/.github/workflows/repo-health.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   repo_health:
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
     uses: OpenVoiceOS/gh-automations/.github/workflows/repo-health.yml@dev
     secrets: inherit
     with:

--- a/hivemind_redis_database/__init__.py
+++ b/hivemind_redis_database/__init__.py
@@ -1,4 +1,4 @@
-from dataclasses import dataclass
+from dataclasses import dataclass, fields
 from typing import List, Optional, Iterable, Union
 import json
 import time
@@ -12,6 +12,7 @@ from hivemind_plugin_manager.database import Client, AbstractRemoteDB, cast2clie
 
 CREATE_MARKER = "__hivemind_creating__"
 CREATE_MARKER_TTL = 30
+CLIENT_SUPPORTS_METADATA = any(field.name == "metadata" for field in fields(Client))
 
 
 @dataclass
@@ -513,7 +514,7 @@ class RedisDB(AbstractRemoteDB):
 
                 client.client_id = self._get_next_client_id()
 
-            serialized_client = client.serialize()
+            serialized_client = self._serialize_client(client)
 
             if self._legacy_cluster_mode():
                 self.redis.set(item_key, serialized_client)
@@ -575,6 +576,10 @@ class RedisDB(AbstractRemoteDB):
             data = json.loads(client_data)
             old_name = data.get('name', '')
             old_api_key = data.get('api_key', '')
+            if CLIENT_SUPPORTS_METADATA and not isinstance(data.get("metadata"), dict):
+                data["metadata"] = {}
+            elif not CLIENT_SUPPORTS_METADATA:
+                data.pop("metadata", None)
 
             # Revoke credentials
             data['name'] = ""
@@ -621,6 +626,33 @@ class RedisDB(AbstractRemoteDB):
         for attr in ['message_blacklist', 'intent_blacklist', 'skill_blacklist']:
             if not hasattr(client, attr) or getattr(client, attr) is None:
                 setattr(client, attr, [])
+        if CLIENT_SUPPORTS_METADATA and (
+            not hasattr(client, "metadata") or not isinstance(client.metadata, dict)
+        ):
+            client.metadata = {}
+
+    def _serialize_client(self, client: Client) -> str:
+        """Serialize clients without metadata when using older plugin-manager."""
+        data = dict(client.__dict__)
+        if CLIENT_SUPPORTS_METADATA:
+            if not isinstance(data.get("metadata"), dict):
+                data["metadata"] = {}
+        else:
+            data.pop("metadata", None)
+        return json.dumps(data, sort_keys=True, ensure_ascii=False)
+
+    def _deserialize_client(self, client_data) -> Client:
+        """Deserialize clients written before or after metadata support."""
+        if isinstance(client_data, str):
+            client_data = json.loads(client_data)
+        if not CLIENT_SUPPORTS_METADATA and isinstance(client_data, dict):
+            client_data = dict(client_data)
+            client_data.pop("metadata", None)
+        elif CLIENT_SUPPORTS_METADATA and isinstance(client_data, dict):
+            if not isinstance(client_data.get("metadata"), dict):
+                client_data = dict(client_data)
+                client_data["metadata"] = {}
+        return cast2client(client_data)
 
     def update_client(self, client: Client) -> bool:
         """
@@ -639,16 +671,16 @@ class RedisDB(AbstractRemoteDB):
                 LOG.warning(f"Client '{client.client_id}' not found for update")
                 return False
 
-            old_client = cast2client(old_client_data)
+            old_client = self._deserialize_client(old_client_data)
             self._ensure_client_attributes(client)
 
             if self._legacy_cluster_mode():
-                self.redis.set(item_key, client.serialize())
+                self.redis.set(item_key, self._serialize_client(client))
                 LOG.debug(f"Successfully updated client '{client.client_id}' in legacy cluster mode")
                 return True
 
             p = self._pipeline()
-            p.set(item_key, client.serialize())
+            p.set(item_key, self._serialize_client(client))
             
             # Update indices only if values changed
             if old_client.name != client.name:
@@ -782,7 +814,7 @@ class RedisDB(AbstractRemoteDB):
                     self.redis.delete(item_key)
                     continue
                 try:
-                    client = cast2client(client_data)
+                    client = self._deserialize_client(client_data)
                     self._ensure_client_attributes(client)
                     client_records.append(client)
                     max_client_id = max(max_client_id, int(client.client_id))
@@ -864,7 +896,7 @@ class RedisDB(AbstractRemoteDB):
             if not client_data or client_data == CREATE_MARKER:
                 continue
             try:
-                client = cast2client(client_data)
+                client = self._deserialize_client(client_data)
                 if not include_revoked and client.api_key == "revoked":
                     continue
                 self._ensure_client_attributes(client)

--- a/tests/test_redisdb.py
+++ b/tests/test_redisdb.py
@@ -1,4 +1,6 @@
 import unittest
+import json
+from dataclasses import fields
 from fnmatch import fnmatch
 from unittest.mock import Mock, patch
 
@@ -8,6 +10,17 @@ from redis.cluster import ClusterNode, key_slot
 from hivemind_plugin_manager import DatabaseFactory
 from hivemind_plugin_manager.database import Client
 from hivemind_redis_database import RedisDB
+
+
+CLIENT_SUPPORTS_METADATA = any(field.name == "metadata" for field in fields(Client))
+METADATA_SUPPORT_REQUIRED = "Client.metadata requires hivemind-plugin-manager metadata support"
+
+
+def make_client(*, metadata=None, **kwargs):
+    client = Client(**kwargs)
+    if metadata is not None:
+        client.metadata = metadata
+    return client
 
 
 class FakeRedis:
@@ -390,6 +403,77 @@ class RedisDBTests(unittest.TestCase):
         self.assertNotIn("client:idx:1", redis_client.hashes)
         self.assertEqual(len(db), 1)
         self.assertEqual([c.name for c in db.search_by_value("name", "alpha")], ["alpha"])
+
+    def test_client_metadata_survives_add_and_search(self):
+        if not CLIENT_SUPPORTS_METADATA:
+            self.skipTest(METADATA_SUPPORT_REQUIRED)
+        redis_client = FakeRedis()
+        db = self.build_db(redis_client)
+
+        client = make_client(
+            client_id=1,
+            api_key="alpha-key",
+            name="alpha",
+            metadata={"owner_id": "owner-123"},
+        )
+        self.assertTrue(db.add_item(client))
+
+        found = db.search_by_value("api_key", "alpha-key")
+
+        self.assertEqual(len(found), 1)
+        self.assertEqual(found[0].metadata, {"owner_id": "owner-123"})
+
+    def test_client_metadata_survives_sync(self):
+        if not CLIENT_SUPPORTS_METADATA:
+            self.skipTest(METADATA_SUPPORT_REQUIRED)
+        redis_client = FakeRedis()
+        db = self.build_db(redis_client)
+        redis_client.storage["client:client:1"] = make_client(
+            client_id=1,
+            api_key="alpha-key",
+            name="alpha",
+            metadata={"owner_id": "owner-123"},
+        ).serialize()
+
+        db.sync()
+        found = db.search_by_value("api_key", "alpha-key")
+
+        self.assertEqual(len(found), 1)
+        self.assertEqual(found[0].metadata, {"owner_id": "owner-123"})
+
+    def test_client_metadata_defaults_to_empty_dict_for_legacy_record(self):
+        if not CLIENT_SUPPORTS_METADATA:
+            self.skipTest(METADATA_SUPPORT_REQUIRED)
+        redis_client = FakeRedis()
+        db = self.build_db(redis_client)
+        legacy_record = json.loads(Client(client_id=1, api_key="alpha-key", name="alpha").serialize())
+        legacy_record.pop("metadata", None)
+        redis_client.storage["client:client:1"] = json.dumps(legacy_record)
+
+        self.assertTrue(db.sync())
+        found = db.search_by_value("api_key", "alpha-key")
+
+        self.assertEqual(len(found), 1)
+        self.assertEqual(found[0].metadata, {})
+
+    def test_client_metadata_survives_revoke(self):
+        if not CLIENT_SUPPORTS_METADATA:
+            self.skipTest(METADATA_SUPPORT_REQUIRED)
+        redis_client = FakeRedis()
+        db = self.build_db(redis_client)
+        client = make_client(
+            client_id=1,
+            api_key="alpha-key",
+            name="alpha",
+            metadata={"owner_id": "owner-123"},
+        )
+        self.assertTrue(db.add_item(client))
+
+        self.assertTrue(db.remove_client("1"))
+
+        stored = Client.deserialize(redis_client.get("client:client:1"))
+        self.assertEqual(stored.api_key, "revoked")
+        self.assertEqual(stored.metadata, {"owner_id": "owner-123"})
 
     def test_legacy_cluster_mode_update_and_revoke_do_not_depend_on_indexes(self):
         redis_client = FakeRedis()


### PR DESCRIPTION
Keeps `Client.metadata` in Redis records through add, search, sync, and revoke.

Needs client metadata support in JarbasHiveMind/hivemind-plugin-manager#21.