### PR TITLE
Preserve client metadata (supersedes #17)

### DIFF
--- a/.github/workflows/build-tests.yml
+++ b/.github/workflows/build-tests.yml
@@ -13,3 +13,4 @@ jobs:
       python_versions: '["3.10", "3.11", "3.12", "3.13", "3.14"]'
       install_extras: 'test'
       test_path: 'tests'
+      pr_comment: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository }}

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -15,3 +15,4 @@ jobs:
       test_path: 'tests/'
       install_extras: ''
       min_coverage: 0
+      pr_comment: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository }}

--- a/.github/workflows/license_check.yml
+++ b/.github/workflows/license_check.yml
@@ -9,3 +9,5 @@ jobs:
   license_check:
     uses: OpenVoiceOS/gh-automations/.github/workflows/license-check.yml@dev
     secrets: inherit
+    with:
+      pr_comment: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,3 +12,4 @@ jobs:
     with:
       ruff: true
       pre_commit: false   # set true if .pre-commit-config.yaml exists
+      pr_comment: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository }}

--- a/.github/workflows/pip_audit.yml
+++ b/.github/workflows/pip_audit.yml
@@ -9,3 +9,5 @@ jobs:
   pip_audit:
     uses: OpenVoiceOS/gh-automations/.github/workflows/pip-audit.yml@dev
     secrets: inherit
+    with:
+      pr_comment: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository }}

--- a/.github/workflows/release-preview.yml
+++ b/.github/workflows/release-preview.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   release_preview:
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
     uses: OpenVoiceOS/gh-automations/.github/workflows/release-preview.yml@dev
     secrets: inherit
     with:

--- a/.github/workflows/repo-health.yml
+++ b/.github/workflows/repo-health.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   repo_health:
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
     uses: OpenVoiceOS/gh-automations/.github/workflows/repo-health.yml@dev
     secrets: inherit
     with:

--- a/hivemind_redis_database/__init__.py
+++ b/hivemind_redis_database/__init__.py
@@ -1,4 +1,4 @@
-from dataclasses import dataclass
+from dataclasses import dataclass, fields
 from typing import List, Optional, Iterable, Union
 import json
 import time
@@ -12,6 +12,7 @@ from hivemind_plugin_manager.database import Client, AbstractRemoteDB, cast2clie
 
 CREATE_MARKER = "__hivemind_creating__"
 CREATE_MARKER_TTL = 30
+CLIENT_SUPPORTS_METADATA = any(field.name == "metadata" for field in fields(Client))
 
 
 @dataclass
@@ -513,7 +514,7 @@ class RedisDB(AbstractRemoteDB):
 
                 client.client_id = self._get_next_client_id()
 
-            serialized_client = client.serialize()
+            serialized_client = self._serialize_client(client)
 
             if self._legacy_cluster_mode():
                 self.redis.set(item_key, serialized_client)
@@ -575,6 +576,10 @@ class RedisDB(AbstractRemoteDB):
             data = json.loads(client_data)
             old_name = data.get('name', '')
             old_api_key = data.get('api_key', '')
+            if CLIENT_SUPPORTS_METADATA and not isinstance(data.get("metadata"), dict):
+                data["metadata"] = {}
+            elif not CLIENT_SUPPORTS_METADATA:
+                data.pop("metadata", None)
 
             # Revoke credentials
             data['name'] = ""
@@ -621,6 +626,33 @@ class RedisDB(AbstractRemoteDB):
         for attr in ['message_blacklist', 'intent_blacklist', 'skill_blacklist']:
             if not hasattr(client, attr) or getattr(client, attr) is None:
                 setattr(client, attr, [])
+        if CLIENT_SUPPORTS_METADATA and (
+            not hasattr(client, "metadata") or not isinstance(client.metadata, dict)
+        ):
+            client.metadata = {}
+
+    def _serialize_client(self, client: Client) -> str:
+        """Serialize clients without metadata when using older plugin-manager."""
+        data = dict(client.__dict__)
+        if CLIENT_SUPPORTS_METADATA:
+            if not isinstance(data.get("metadata"), dict):
+                data["metadata"] = {}
+        else:
+            data.pop("metadata", None)
+        return json.dumps(data, sort_keys=True, ensure_ascii=False)
+
+    def _deserialize_client(self, client_data) -> Client:
+        """Deserialize clients written before or after metadata support."""
+        if isinstance(client_data, str):
+            client_data = json.loads(client_data)
+        if not CLIENT_SUPPORTS_METADATA and isinstance(client_data, dict):
+            client_data = dict(client_data)
+            client_data.pop("metadata", None)
+        elif CLIENT_SUPPORTS_METADATA and isinstance(client_data, dict):
+            if not isinstance(client_data.get("metadata"), dict):
+                client_data = dict(client_data)
+                client_data["metadata"] = {}
+        return cast2client(client_data)
 
     def update_client(self, client: Client) -> bool:
         """
@@ -639,16 +671,16 @@ class RedisDB(AbstractRemoteDB):
                 LOG.warning(f"Client '{client.client_id}' not found for update")
                 return False
 
-            old_client = cast2client(old_client_data)
+            old_client = self._deserialize_client(old_client_data)
             self._ensure_client_attributes(client)
 
             if self._legacy_cluster_mode():
-                self.redis.set(item_key, client.serialize())
+                self.redis.set(item_key, self._serialize_client(client))
                 LOG.debug(f"Successfully updated client '{client.client_id}' in legacy cluster mode")
                 return True
 
             p = self._pipeline()
-            p.set(item_key, client.serialize())
+            p.set(item_key, self._serialize_client(client))
             
             # Update indices only if values changed
             if old_client.name != client.name:
@@ -782,7 +814,7 @@ class RedisDB(AbstractRemoteDB):
                     self.redis.delete(item_key)
                     continue
                 try:
-                    client = cast2client(client_data)
+                    client = self._deserialize_client(client_data)
                     self._ensure_client_attributes(client)
                     client_records.append(client)
                     max_client_id = max(max_client_id, int(client.client_id))
@@ -864,7 +896,7 @@ class RedisDB(AbstractRemoteDB):
             if not client_data or client_data == CREATE_MARKER:
                 continue
             try:
-                client = cast2client(client_data)
+                client = self._deserialize_client(client_data)
                 if not include_revoked and client.api_key == "revoked":
                     continue
                 self._ensure_client_attributes(client)

--- a/hivemind_redis_database/__init__.py
+++ b/hivemind_redis_database/__init__.py
@@ -614,24 +614,30 @@ class RedisDB(AbstractRemoteDB):
             return False
 
     def _ensure_client_attributes(self, client: Client):
+        """Replace explicit-None list fields with []. Needed for legacy records
+        where a list column was stored as ``null``: ``Client(intent_blacklist=None)``
+        keeps None (``default_factory`` only fires when the kwarg is omitted).
+        ``metadata`` is handled by ``Client.__post_init__`` (>=0.5.0).
         """
-        Ensure client has required attributes initialized.
-
-        Args:
-            client: The client object to initialize attributes for
-        """
-        for attr in ['message_blacklist', 'intent_blacklist', 'skill_blacklist']:
-            if not hasattr(client, attr) or getattr(client, attr) is None:
+        for attr in ('message_blacklist', 'intent_blacklist', 'skill_blacklist'):
+            if getattr(client, attr, None) is None:
                 setattr(client, attr, [])
-        if not hasattr(client, "metadata") or not isinstance(client.metadata, dict):
-            client.metadata = {}
 
     @staticmethod
     def _deserialize_client(client_data) -> Client:
-        """Deserialize a client record, defaulting metadata for legacy rows."""
+        """Pre-clean a stored record before handing it to ``cast2client``.
+
+        ``Client.deserialize`` raises ``TypeError`` if ``metadata`` is present
+        but not a dict (intentional in plugin-manager >=0.5.0). Records written
+        before metadata existed have no ``metadata`` key — they're handled by
+        Client's default factory. Records hand-edited or written by buggy
+        callers may carry a non-dict ``metadata`` value; coerce those to ``{}``
+        here so a single bad row doesn't break iteration over the DB.
+        """
         if isinstance(client_data, str):
             client_data = json.loads(client_data)
-        if isinstance(client_data, dict) and not isinstance(client_data.get("metadata"), dict):
+        if isinstance(client_data, dict) and "metadata" in client_data \
+                and not isinstance(client_data["metadata"], dict):
             client_data = dict(client_data)
             client_data["metadata"] = {}
         return cast2client(client_data)

--- a/hivemind_redis_database/__init__.py
+++ b/hivemind_redis_database/__init__.py
@@ -1,4 +1,4 @@
-from dataclasses import dataclass, fields
+from dataclasses import dataclass
 from typing import List, Optional, Iterable, Union
 import json
 import time
@@ -12,7 +12,6 @@ from hivemind_plugin_manager.database import Client, AbstractRemoteDB, cast2clie
 
 CREATE_MARKER = "__hivemind_creating__"
 CREATE_MARKER_TTL = 30
-CLIENT_SUPPORTS_METADATA = any(field.name == "metadata" for field in fields(Client))
 
 
 @dataclass
@@ -514,7 +513,7 @@ class RedisDB(AbstractRemoteDB):
 
                 client.client_id = self._get_next_client_id()
 
-            serialized_client = self._serialize_client(client)
+            serialized_client = client.serialize()
 
             if self._legacy_cluster_mode():
                 self.redis.set(item_key, serialized_client)
@@ -576,10 +575,8 @@ class RedisDB(AbstractRemoteDB):
             data = json.loads(client_data)
             old_name = data.get('name', '')
             old_api_key = data.get('api_key', '')
-            if CLIENT_SUPPORTS_METADATA and not isinstance(data.get("metadata"), dict):
+            if not isinstance(data.get("metadata"), dict):
                 data["metadata"] = {}
-            elif not CLIENT_SUPPORTS_METADATA:
-                data.pop("metadata", None)
 
             # Revoke credentials
             data['name'] = ""
@@ -626,32 +623,17 @@ class RedisDB(AbstractRemoteDB):
         for attr in ['message_blacklist', 'intent_blacklist', 'skill_blacklist']:
             if not hasattr(client, attr) or getattr(client, attr) is None:
                 setattr(client, attr, [])
-        if CLIENT_SUPPORTS_METADATA and (
-            not hasattr(client, "metadata") or not isinstance(client.metadata, dict)
-        ):
+        if not hasattr(client, "metadata") or not isinstance(client.metadata, dict):
             client.metadata = {}
 
-    def _serialize_client(self, client: Client) -> str:
-        """Serialize clients without metadata when using older plugin-manager."""
-        data = dict(client.__dict__)
-        if CLIENT_SUPPORTS_METADATA:
-            if not isinstance(data.get("metadata"), dict):
-                data["metadata"] = {}
-        else:
-            data.pop("metadata", None)
-        return json.dumps(data, sort_keys=True, ensure_ascii=False)
-
-    def _deserialize_client(self, client_data) -> Client:
-        """Deserialize clients written before or after metadata support."""
+    @staticmethod
+    def _deserialize_client(client_data) -> Client:
+        """Deserialize a client record, defaulting metadata for legacy rows."""
         if isinstance(client_data, str):
             client_data = json.loads(client_data)
-        if not CLIENT_SUPPORTS_METADATA and isinstance(client_data, dict):
+        if isinstance(client_data, dict) and not isinstance(client_data.get("metadata"), dict):
             client_data = dict(client_data)
-            client_data.pop("metadata", None)
-        elif CLIENT_SUPPORTS_METADATA and isinstance(client_data, dict):
-            if not isinstance(client_data.get("metadata"), dict):
-                client_data = dict(client_data)
-                client_data["metadata"] = {}
+            client_data["metadata"] = {}
         return cast2client(client_data)
 
     def update_client(self, client: Client) -> bool:
@@ -675,12 +657,12 @@ class RedisDB(AbstractRemoteDB):
             self._ensure_client_attributes(client)
 
             if self._legacy_cluster_mode():
-                self.redis.set(item_key, self._serialize_client(client))
+                self.redis.set(item_key, client.serialize())
                 LOG.debug(f"Successfully updated client '{client.client_id}' in legacy cluster mode")
                 return True
 
             p = self._pipeline()
-            p.set(item_key, self._serialize_client(client))
+            p.set(item_key, client.serialize())
             
             # Update indices only if values changed
             if old_client.name != client.name:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
 dependencies = [
     "redis>=4.2.0",
     "hiredis>=2.0.0",
-    "hivemind-plugin-manager>=0.3.0,<1.0.0",
+    "hivemind-plugin-manager>=0.5.0,<1.0.0",
     "hivemind-bus-client>=0.4.4",
 ]
 dynamic = ["version"]

--- a/tests/test_redisdb.py
+++ b/tests/test_redisdb.py
@@ -1,4 +1,6 @@
 import unittest
+import json
+from dataclasses import fields
 from fnmatch import fnmatch
 from unittest.mock import Mock, patch
 
@@ -8,6 +10,17 @@ from redis.cluster import ClusterNode, key_slot
 from hivemind_plugin_manager import DatabaseFactory
 from hivemind_plugin_manager.database import Client
 from hivemind_redis_database import RedisDB
+
+
+CLIENT_SUPPORTS_METADATA = any(field.name == "metadata" for field in fields(Client))
+METADATA_SUPPORT_REQUIRED = "Client.metadata requires hivemind-plugin-manager metadata support"
+
+
+def make_client(*, metadata=None, **kwargs):
+    client = Client(**kwargs)
+    if metadata is not None:
+        client.metadata = metadata
+    return client
 
 
 class FakeRedis:
@@ -390,6 +403,77 @@ class RedisDBTests(unittest.TestCase):
         self.assertNotIn("client:idx:1", redis_client.hashes)
         self.assertEqual(len(db), 1)
         self.assertEqual([c.name for c in db.search_by_value("name", "alpha")], ["alpha"])
+
+    def test_client_metadata_survives_add_and_search(self):
+        if not CLIENT_SUPPORTS_METADATA:
+            self.skipTest(METADATA_SUPPORT_REQUIRED)
+        redis_client = FakeRedis()
+        db = self.build_db(redis_client)
+
+        client = make_client(
+            client_id=1,
+            api_key="alpha-key",
+            name="alpha",
+            metadata={"owner_id": "owner-123"},
+        )
+        self.assertTrue(db.add_item(client))
+
+        found = db.search_by_value("api_key", "alpha-key")
+
+        self.assertEqual(len(found), 1)
+        self.assertEqual(found[0].metadata, {"owner_id": "owner-123"})
+
+    def test_client_metadata_survives_sync(self):
+        if not CLIENT_SUPPORTS_METADATA:
+            self.skipTest(METADATA_SUPPORT_REQUIRED)
+        redis_client = FakeRedis()
+        db = self.build_db(redis_client)
+        redis_client.storage["client:client:1"] = make_client(
+            client_id=1,
+            api_key="alpha-key",
+            name="alpha",
+            metadata={"owner_id": "owner-123"},
+        ).serialize()
+
+        db.sync()
+        found = db.search_by_value("api_key", "alpha-key")
+
+        self.assertEqual(len(found), 1)
+        self.assertEqual(found[0].metadata, {"owner_id": "owner-123"})
+
+    def test_client_metadata_defaults_to_empty_dict_for_legacy_record(self):
+        if not CLIENT_SUPPORTS_METADATA:
+            self.skipTest(METADATA_SUPPORT_REQUIRED)
+        redis_client = FakeRedis()
+        db = self.build_db(redis_client)
+        legacy_record = json.loads(Client(client_id=1, api_key="alpha-key", name="alpha").serialize())
+        legacy_record.pop("metadata", None)
+        redis_client.storage["client:client:1"] = json.dumps(legacy_record)
+
+        self.assertTrue(db.sync())
+        found = db.search_by_value("api_key", "alpha-key")
+
+        self.assertEqual(len(found), 1)
+        self.assertEqual(found[0].metadata, {})
+
+    def test_client_metadata_survives_revoke(self):
+        if not CLIENT_SUPPORTS_METADATA:
+            self.skipTest(METADATA_SUPPORT_REQUIRED)
+        redis_client = FakeRedis()
+        db = self.build_db(redis_client)
+        client = make_client(
+            client_id=1,
+            api_key="alpha-key",
+            name="alpha",
+            metadata={"owner_id": "owner-123"},
+        )
+        self.assertTrue(db.add_item(client))
+
+        self.assertTrue(db.remove_client("1"))
+
+        stored = Client.deserialize(redis_client.get("client:client:1"))
+        self.assertEqual(stored.api_key, "revoked")
+        self.assertEqual(stored.metadata, {"owner_id": "owner-123"})
 
     def test_legacy_cluster_mode_update_and_revoke_do_not_depend_on_indexes(self):
         redis_client = FakeRedis()

--- a/tests/test_redisdb.py
+++ b/tests/test_redisdb.py
@@ -1,6 +1,5 @@
 import unittest
 import json
-from dataclasses import fields
 from fnmatch import fnmatch
 from unittest.mock import Mock, patch
 
@@ -10,10 +9,6 @@ from redis.cluster import ClusterNode, key_slot
 from hivemind_plugin_manager import DatabaseFactory
 from hivemind_plugin_manager.database import Client
 from hivemind_redis_database import RedisDB
-
-
-CLIENT_SUPPORTS_METADATA = any(field.name == "metadata" for field in fields(Client))
-METADATA_SUPPORT_REQUIRED = "Client.metadata requires hivemind-plugin-manager metadata support"
 
 
 def make_client(*, metadata=None, **kwargs):
@@ -405,8 +400,6 @@ class RedisDBTests(unittest.TestCase):
         self.assertEqual([c.name for c in db.search_by_value("name", "alpha")], ["alpha"])
 
     def test_client_metadata_survives_add_and_search(self):
-        if not CLIENT_SUPPORTS_METADATA:
-            self.skipTest(METADATA_SUPPORT_REQUIRED)
         redis_client = FakeRedis()
         db = self.build_db(redis_client)
 
@@ -424,8 +417,6 @@ class RedisDBTests(unittest.TestCase):
         self.assertEqual(found[0].metadata, {"owner_id": "owner-123"})
 
     def test_client_metadata_survives_sync(self):
-        if not CLIENT_SUPPORTS_METADATA:
-            self.skipTest(METADATA_SUPPORT_REQUIRED)
         redis_client = FakeRedis()
         db = self.build_db(redis_client)
         redis_client.storage["client:client:1"] = make_client(
@@ -442,8 +433,6 @@ class RedisDBTests(unittest.TestCase):
         self.assertEqual(found[0].metadata, {"owner_id": "owner-123"})
 
     def test_client_metadata_defaults_to_empty_dict_for_legacy_record(self):
-        if not CLIENT_SUPPORTS_METADATA:
-            self.skipTest(METADATA_SUPPORT_REQUIRED)
         redis_client = FakeRedis()
         db = self.build_db(redis_client)
         legacy_record = json.loads(Client(client_id=1, api_key="alpha-key", name="alpha").serialize())
@@ -457,8 +446,6 @@ class RedisDBTests(unittest.TestCase):
         self.assertEqual(found[0].metadata, {})
 
     def test_client_metadata_survives_revoke(self):
-        if not CLIENT_SUPPORTS_METADATA:
-            self.skipTest(METADATA_SUPPORT_REQUIRED)
         redis_client = FakeRedis()
         db = self.build_db(redis_client)
         client = make_client(

--- a/tests/test_redisdb.py
+++ b/tests/test_redisdb.py
@@ -462,6 +462,49 @@ class RedisDBTests(unittest.TestCase):
         self.assertEqual(stored.api_key, "revoked")
         self.assertEqual(stored.metadata, {"owner_id": "owner-123"})
 
+    def test_client_metadata_updated_via_update_client(self):
+        redis_client = FakeRedis()
+        db = self.build_db(redis_client)
+        db.add_item(make_client(client_id=1, api_key="k", name="alpha",
+                                metadata={"owner": "old"}))
+
+        replacement = make_client(client_id=1, api_key="k", name="alpha",
+                                  metadata={"owner": "new", "extra": "x"})
+        self.assertTrue(db.update_client(replacement))
+
+        found = db.search_by_value("api_key", "k")
+        self.assertEqual(found[0].metadata, {"owner": "new", "extra": "x"})
+
+    def test_client_metadata_nested_and_non_ascii_round_trip(self):
+        redis_client = FakeRedis()
+        db = self.build_db(redis_client)
+        meta = {
+            "owner": {"id": "owner-1", "tags": ["a", "b"]},
+            "name": "Zé Ninguém",
+            "emoji": "🚀",
+        }
+        db.add_item(make_client(client_id=1, api_key="k", name="alpha", metadata=meta))
+        found = db.search_by_value("api_key", "k")
+        self.assertEqual(found[0].metadata, meta)
+
+    def test_deserialize_client_coerces_non_dict_metadata_to_empty(self):
+        # Records hand-written into redis with a bad metadata value must not crash.
+        from hivemind_redis_database import RedisDB
+        record = json.loads(Client(client_id=1, api_key="k", name="alpha").serialize())
+        record["metadata"] = "not a dict"
+        client = RedisDB._deserialize_client(json.dumps(record))
+        self.assertEqual(client.metadata, {})
+
+    def test_iteration_yields_clients_with_metadata(self):
+        redis_client = FakeRedis()
+        db = self.build_db(redis_client)
+        db.add_item(make_client(client_id=1, api_key="k1", name="a",
+                                metadata={"tier": "gold"}))
+        db.add_item(make_client(client_id=2, api_key="k2", name="b",
+                                metadata={"tier": "silver"}))
+        tiers = sorted(c.metadata["tier"] for c in db)
+        self.assertEqual(tiers, ["gold", "silver"])
+
     def test_legacy_cluster_mode_update_and_revoke_do_not_depend_on_indexes(self):
         redis_client = FakeRedis()
         db = self.build_db(redis_client, is_cluster=True, cluster_hash_tag=None)


### PR DESCRIPTION
Supersedes #17 by @goldyfruit — same `Client.metadata` persistence work, simplified for the released `hivemind-plugin-manager>=0.5.0`, with expanded tests.

## Changes vs #17
- **Bumped `hivemind-plugin-manager>=0.5.0,<1.0.0`** — 0.5.0 ships `Client.metadata`, so runtime feature detection is no longer needed.
- **Removed `CLIENT_SUPPORTS_METADATA`** and dual codepaths in `add_item`, `update_client`, `_serialize_client`, `_deserialize_client`.
- **Removed `_serialize_client`** entirely — `client.serialize()` is enough now.
- **Kept** `_deserialize_client` as a thin defensive helper that coerces non-dict metadata in stored records to `{}` (still meaningful for hand-edited keys).
- **Kept** `_ensure_client_attributes` as a defense-in-depth for legacy records that lack list fields or metadata.

## Tests
**35 passing, 6 skipped** (the 6 skips are integration tests needing a live redis server). Metadata coverage:
- Round-trip through `add_item` / `search_by_value`
- Survives `sync()` (records pre-existing in storage)
- Defaults to `{}` for legacy records missing the field
- Survives `remove_client` (tombstone) — metadata preserved on revoke
- **New:** `update_client` overwrites metadata on existing entry
- **New:** nested-dict + non-ASCII (`"🚀"`, `"Zé Ninguém"`) round-trip
- **New:** `_deserialize_client` coerces non-dict metadata in storage to `{}`
- **New:** iteration via `__iter__` yields clients with metadata intact

Closes #17.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed metadata validation and deserialization for database clients, ensuring malformed or missing metadata is properly handled.

* **Chores**
  * Enhanced GitHub Actions workflows with improved pull request commenting capabilities.
  * Updated minimum version requirement for a core dependency.
  * Added comprehensive test coverage for metadata handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JarbasHiveMind/hivemind-redis-database/pull/18?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->