### PR TITLE
Use indexed API-key lookup and larger Redis pool

### DIFF
--- a/hivemind_redis_database/__init__.py
+++ b/hivemind_redis_database/__init__.py
@@ -54,7 +54,7 @@ class RedisDB(AbstractRemoteDB):
         cluster_nodes (Optional[List[dict]]): Redis Cluster node configuration
         cluster_hash_tag (Optional[str]): Fixed Redis Cluster hash tag for single-slot writes
         index_prefix (str): Key prefix for all database operations (default: "client")
-        max_connections (int): Maximum connection pool size (default: 5)
+        max_connections (int): Maximum connection pool size (default: 64)
         retry_attempts (int): Number of retry attempts (default: 3)
         retry_delay (float): Delay between retry attempts in seconds (default: 0.1)
         use_ssl (bool): Enable SSL/TLS connection (default: False)
@@ -73,7 +73,7 @@ class RedisDB(AbstractRemoteDB):
     cluster_nodes: Optional[List[dict]] = None
     cluster_hash_tag: Optional[str] = None
     index_prefix: str = "client"
-    max_connections: int = 5
+    max_connections: int = 64
     retry_attempts: int = 3
     retry_delay: float = 0.1
     use_ssl: bool = False
@@ -368,9 +368,9 @@ class RedisDB(AbstractRemoteDB):
         connection_kwargs.update(self._get_ssl_kwargs())
 
         client = redis.StrictRedis(
-            **connection_kwargs,
             retry=self._retry_policy(),
             retry_on_error=[redis.ConnectionError, redis.TimeoutError],
+            **connection_kwargs,
         )
         self.redis_pool = client.connection_pool
         return client
@@ -919,6 +919,33 @@ class RedisDB(AbstractRemoteDB):
                     res.append(client)
         return res
 
+    def get_client_by_api_key(self, api_key: str) -> Optional[Client]:
+        """Return the client for an API key without requiring a full sync.
+
+        API-key lookup is on the admission path in hivemind-core, so unknown
+        keys must fail through indexed lookups only. ``sync()`` remains the
+        explicit repair path for interrupted/manual writes that leave secondary
+        indexes stale.
+        """
+        if api_key is None:
+            return None
+        api_key = str(api_key)
+
+        if self._legacy_cluster_mode():
+            matches = self._search_brute_force("api_key", api_key)
+            return matches[0] if matches else None
+
+        for client in self._search_with_index("api_key", api_key):
+            if client.api_key == api_key:
+                return client
+
+        if self.redisearch_available:
+            for client in self._search_with_redisearch("api_key", api_key):
+                if client.api_key == api_key:
+                    return client
+
+        return None
+
     def search_by_value(self, key: str, val) -> List[Client]:
         """
         Search for clients by a specific key-value pair in Redis.
@@ -930,6 +957,10 @@ class RedisDB(AbstractRemoteDB):
         Returns:
             A list of clients that match the search criteria.
         """
+        if key == 'api_key':
+            client = self.get_client_by_api_key(val)
+            return [client] if client else []
+
         if self._legacy_cluster_mode():
             return self._search_brute_force(key, val)
 

--- a/tests/test_redisdb.py
+++ b/tests/test_redisdb.py
@@ -25,6 +25,7 @@ class FakeRedis:
         self.connection_pool = Mock()
         self.pipeline_transaction_flags = []
         self.mget_calls = []
+        self.scan_count = 0
 
     def exists(self, key):
         return key in self.storage or key in self.hashes
@@ -88,6 +89,7 @@ class FakeRedis:
         return 1
 
     def scan_iter(self, pattern, count=None):
+        self.scan_count += 1
         del count
         for key in sorted(set(self.storage) | set(self.hashes)):
             if fnmatch(key, pattern):
@@ -295,6 +297,29 @@ class RedisDBTests(unittest.TestCase):
         self.assertEqual(ssl_kwargs["ssl_cert_reqs"], "none")
         self.assertFalse(ssl_kwargs["ssl_check_hostname"])
 
+    @patch("hivemind_redis_database.redis.StrictRedis")
+    def test_create_single_connection_uses_configured_pool_size(self, strict_redis):
+        db = object.__new__(RedisDB)
+        db.host = "redis.example.com"
+        db.port = 6379
+        db.db = 0
+        db.password = "secret"
+        db.username = "default"
+        db.max_connections = 64
+        db.retry_attempts = 3
+        db.retry_delay = 0.1
+        db.use_ssl = False
+        db.ssl_certfile = None
+        db.ssl_keyfile = None
+        db.ssl_ca_certs = None
+        db.ssl_cert_reqs = "required"
+        db.ssl_check_hostname = True
+
+        db._create_single_connection()
+
+        strict_redis.assert_called_once()
+        self.assertEqual(strict_redis.call_args.kwargs["max_connections"], 64)
+
     @patch("hivemind_redis_database.redis.RedisCluster")
     def test_create_cluster_connection_uses_retry_policy(self, redis_cluster):
         db = object.__new__(RedisDB)
@@ -415,6 +440,47 @@ class RedisDBTests(unittest.TestCase):
 
         self.assertEqual(len(found), 1)
         self.assertEqual(found[0].metadata, {"owner_id": "owner-123"})
+
+    def test_get_client_by_api_key_uses_secondary_index(self):
+        redis_client = FakeRedis()
+        db = self.build_db(redis_client)
+
+        client = Client(client_id=1, api_key="alpha-key", name="alpha")
+        self.assertTrue(db.add_item(client))
+
+        found = db.get_client_by_api_key("alpha-key")
+
+        self.assertIsNotNone(found)
+        self.assertEqual(found.client_id, 1)
+        self.assertEqual(redis_client.mget_calls[-1], ["client:client:1"])
+
+    def test_get_client_by_api_key_does_not_scan_on_index_miss(self):
+        redis_client = FakeRedis()
+        db = self.build_db(redis_client)
+        redis_client.storage["client:client:1"] = Client(
+            client_id=1,
+            api_key="alpha-key",
+            name="alpha",
+        ).serialize()
+
+        found = db.get_client_by_api_key("alpha-key")
+
+        self.assertIsNone(found)
+        self.assertEqual(redis_client.scan_count, 0)
+
+    def test_search_by_api_key_does_not_scan_on_index_miss(self):
+        redis_client = FakeRedis()
+        db = self.build_db(redis_client)
+        redis_client.storage["client:client:1"] = Client(
+            client_id=1,
+            api_key="alpha-key",
+            name="alpha",
+        ).serialize()
+
+        found = db.search_by_value("api_key", "alpha-key")
+
+        self.assertEqual(found, [])
+        self.assertEqual(redis_client.scan_count, 0)
 
     def test_client_metadata_survives_sync(self):
         redis_client = FakeRedis()
@@ -711,7 +777,6 @@ class TestRedisDBRefresh(unittest.TestCase):
         db.redisearch_available = False
         fake.storage["client:client:5"] = "__hivemind_creating__"
         self.assertIsNone(db.refresh(5))
-
 
 class TestRedisDBPipelineTransactional(unittest.TestCase):
     """Single-node Redis must use transactional pipelines so add_item /


### PR DESCRIPTION
Adds get_client_by_api_key for the auth hot path and keeps it index-only in normal Redis mode. Unknown API keys now fail through the existing index/RediSearch paths; there is no full keyspace scan on miss.

Also raises the default Redis connection cap from 5 to 64. The blocking pool path was removed after review.

Tested:
- PYTHONPATH=. pytest tests/test_redisdb.py -q