### PR TITLE
fix: advance last_seen atomically

### DIFF
--- a/hivemind_redis_database/__init__.py
+++ b/hivemind_redis_database/__init__.py
@@ -14,6 +14,24 @@ from hivemind_plugin_manager.database import (Client, AbstractDB,
 CREATE_MARKER = "__hivemind_creating__"
 CREATE_MARKER_TTL = 30
 
+_ADVANCE_LAST_SEEN_LUA = """
+local raw = redis.call('GET', KEYS[1])
+if not raw or raw == ARGV[3] then
+    return 0
+end
+local client = cjson.decode(raw)
+if client.api_key ~= ARGV[1] then
+    return 0
+end
+local current = tonumber(client.last_seen) or -1
+local incoming = tonumber(ARGV[2])
+if incoming > current then
+    client.last_seen = incoming
+    redis.call('SET', KEYS[1], cjson.encode(client))
+end
+return 1
+"""
+
 
 def _iter_client_records_safely(db) -> "Iterable[tuple[str, str]]":
     """Yield (key, raw_value) pairs for every stored client record in the
@@ -818,6 +836,26 @@ class RedisDB(AbstractRemoteDB):
             return True
         except Exception as e:
             LOG.error(f"Failed to update client '{client.client_id}': {e}")
+            return False
+
+    def update_last_seen(self, api_key: str, seen_at: float) -> bool:
+        """Atomically advance ``last_seen`` for the matching API key."""
+        try:
+            client = self.get_client_by_api_key(api_key)
+            if client is None:
+                return False
+            return bool(
+                self.redis.eval(
+                    _ADVANCE_LAST_SEEN_LUA,
+                    1,
+                    self._client_key(client.client_id),
+                    api_key,
+                    float(seen_at),
+                    CREATE_MARKER,
+                )
+            )
+        except Exception as e:
+            LOG.error(f"Failed to update last_seen for client '{api_key}': {e}")
             return False
 
     def get_client_by_id(self, client_id: int) -> Optional[Client]:

--- a/tests/test_redisdb.py
+++ b/tests/test_redisdb.py
@@ -102,6 +102,18 @@ class FakeRedis:
     def ping(self):
         return True
 
+    def eval(self, _script, numkeys, key, api_key, seen_at, create_marker):
+        assert numkeys == 1
+        raw = self.get(key)
+        if not raw or raw == create_marker:
+            return 0
+        client = json.loads(raw)
+        if client.get("api_key") != api_key:
+            return 0
+        client["last_seen"] = max(float(client.get("last_seen", -1)), float(seen_at))
+        self.set(key, json.dumps(client))
+        return 1
+
 
 class FakePipeline:
     def __init__(self, redis_client):
@@ -467,6 +479,33 @@ class RedisDBTests(unittest.TestCase):
 
         self.assertIsNone(found)
         self.assertEqual(redis_client.scan_count, 0)
+
+    def test_update_last_seen_never_moves_timestamp_backward(self):
+        redis_client = FakeRedis()
+        db = self.build_db(redis_client)
+        client = Client(client_id=1, api_key="alpha-key", name="alpha", last_seen=200.0)
+        self.assertTrue(db.add_item(client))
+
+        self.assertTrue(db.update_last_seen("alpha-key", 100.0))
+        self.assertEqual(db.get_client_by_api_key("alpha-key").last_seen, 200.0)
+
+        self.assertTrue(db.update_last_seen("alpha-key", 300.0))
+        self.assertEqual(db.get_client_by_api_key("alpha-key").last_seen, 300.0)
+
+    def test_update_last_seen_rejects_missing_or_reassigned_api_key(self):
+        redis_client = FakeRedis()
+        db = self.build_db(redis_client)
+        client = Client(client_id=1, api_key="alpha-key", name="alpha")
+        self.assertTrue(db.add_item(client))
+
+        self.assertFalse(db.update_last_seen("missing-key", 100.0))
+
+        redis_client.storage["client:client:1"] = Client(
+            client_id=1,
+            api_key="replacement-key",
+            name="alpha",
+        ).serialize()
+        self.assertFalse(db.update_last_seen("alpha-key", 100.0))
 
     def test_search_by_api_key_does_not_scan_on_index_miss(self):
         redis_client = FakeRedis()


### PR DESCRIPTION
Adds a Redis-side conditional update so delayed asynchronous writers cannot move a client activity timestamp backward. The Lua update verifies the API key and stores only a greater timestamp.\n\nValidation: 63 passed, 6 skipped; ruff and diff checks passed.\n\nPairs with JarbasHiveMind/HiveMind-core#150.