### PR TITLE
ci: release safely after fork merges

### DIFF
--- a/.github/workflows/publish_stable.yml
+++ b/.github/workflows/publish_stable.yml
@@ -20,4 +20,4 @@ jobs:
       publish_pypi: true
       publish_release: true
       sync_dev: true
-      notify_matrix: true
+      notify_matrix: false

--- a/.github/workflows/release_workflow.yml
+++ b/.github/workflows/release_workflow.yml
@@ -2,7 +2,7 @@ name: Release Alpha and Propose Stable
 
 on:
   workflow_dispatch:
-  pull_request:
+  pull_request_target:
     types: [closed]
     branches: [dev]
 
@@ -25,4 +25,4 @@ jobs:
       propose_release: true
       changelog_max_issues: 50
       publish_pypi: true
-      notify_matrix: true
+      notify_matrix: false


### PR DESCRIPTION
## Summary
- use `pull_request_target` for the closed/merged release trigger so the base repository token can bump `dev`
- keep explicit contents and pull-request write permissions
- disable the failing optional Matrix notification

The target workflow reads and publishes the trusted `dev` branch; it never checks out or executes the fork head.

## Validation
- parsed every workflow as YAML
- `git diff --check`