### PR TITLE
Revert unauthorized automated merges (#31, #32, #33)

### DIFF
--- a/.github/workflows/publish_stable.yml
+++ b/.github/workflows/publish_stable.yml
@@ -20,4 +20,4 @@ jobs:
       publish_pypi: true
       publish_release: true
       sync_dev: true
-      notify_matrix: false
+      notify_matrix: true

--- a/.github/workflows/release_workflow.yml
+++ b/.github/workflows/release_workflow.yml
@@ -2,7 +2,7 @@ name: Release Alpha and Propose Stable
 
 on:
   workflow_dispatch:
-  pull_request_target:
+  pull_request:
     types: [closed]
     branches: [dev]
 
@@ -25,4 +25,4 @@ jobs:
       propose_release: true
       changelog_max_issues: 50
       publish_pypi: true
-      notify_matrix: false
+      notify_matrix: true

--- a/hivemind_redis_database/__init__.py
+++ b/hivemind_redis_database/__init__.py
@@ -54,7 +54,7 @@ class RedisDB(AbstractRemoteDB):
         cluster_nodes (Optional[List[dict]]): Redis Cluster node configuration
         cluster_hash_tag (Optional[str]): Fixed Redis Cluster hash tag for single-slot writes
         index_prefix (str): Key prefix for all database operations (default: "client")
-        max_connections (int): Maximum connection pool size (default: 64)
+        max_connections (int): Maximum connection pool size (default: 5)
         retry_attempts (int): Number of retry attempts (default: 3)
         retry_delay (float): Delay between retry attempts in seconds (default: 0.1)
         use_ssl (bool): Enable SSL/TLS connection (default: False)
@@ -73,7 +73,7 @@ class RedisDB(AbstractRemoteDB):
     cluster_nodes: Optional[List[dict]] = None
     cluster_hash_tag: Optional[str] = None
     index_prefix: str = "client"
-    max_connections: int = 64
+    max_connections: int = 5
     retry_attempts: int = 3
     retry_delay: float = 0.1
     use_ssl: bool = False
@@ -368,9 +368,9 @@ class RedisDB(AbstractRemoteDB):
         connection_kwargs.update(self._get_ssl_kwargs())
 
         client = redis.StrictRedis(
+            **connection_kwargs,
             retry=self._retry_policy(),
             retry_on_error=[redis.ConnectionError, redis.TimeoutError],
-            **connection_kwargs,
         )
         self.redis_pool = client.connection_pool
         return client
@@ -919,33 +919,6 @@ class RedisDB(AbstractRemoteDB):
                     res.append(client)
         return res
 
-    def get_client_by_api_key(self, api_key: str) -> Optional[Client]:
-        """Return the client for an API key without requiring a full sync.
-
-        API-key lookup is on the admission path in hivemind-core, so unknown
-        keys must fail through indexed lookups only. ``sync()`` remains the
-        explicit repair path for interrupted/manual writes that leave secondary
-        indexes stale.
-        """
-        if api_key is None:
-            return None
-        api_key = str(api_key)
-
-        if self._legacy_cluster_mode():
-            matches = self._search_brute_force("api_key", api_key)
-            return matches[0] if matches else None
-
-        for client in self._search_with_index("api_key", api_key):
-            if client.api_key == api_key:
-                return client
-
-        if self.redisearch_available:
-            for client in self._search_with_redisearch("api_key", api_key):
-                if client.api_key == api_key:
-                    return client
-
-        return None
-
     def search_by_value(self, key: str, val) -> List[Client]:
         """
         Search for clients by a specific key-value pair in Redis.
@@ -957,10 +930,6 @@ class RedisDB(AbstractRemoteDB):
         Returns:
             A list of clients that match the search criteria.
         """
-        if key == 'api_key':
-            client = self.get_client_by_api_key(val)
-            return [client] if client else []
-
         if self._legacy_cluster_mode():
             return self._search_brute_force(key, val)
 

--- a/hivemind_redis_database/__init__.py
+++ b/hivemind_redis_database/__init__.py
@@ -14,24 +14,6 @@ from hivemind_plugin_manager.database import (Client, AbstractDB,
 CREATE_MARKER = "__hivemind_creating__"
 CREATE_MARKER_TTL = 30
 
-_ADVANCE_LAST_SEEN_LUA = """
-local raw = redis.call('GET', KEYS[1])
-if not raw or raw == ARGV[3] then
-    return 0
-end
-local client = cjson.decode(raw)
-if client.api_key ~= ARGV[1] then
-    return 0
-end
-local current = tonumber(client.last_seen) or -1
-local incoming = tonumber(ARGV[2])
-if incoming > current then
-    client.last_seen = incoming
-    redis.call('SET', KEYS[1], cjson.encode(client))
-end
-return 1
-"""
-
 
 def _iter_client_records_safely(db) -> "Iterable[tuple[str, str]]":
     """Yield (key, raw_value) pairs for every stored client record in the
@@ -836,26 +818,6 @@ class RedisDB(AbstractRemoteDB):
             return True
         except Exception as e:
             LOG.error(f"Failed to update client '{client.client_id}': {e}")
-            return False
-
-    def update_last_seen(self, api_key: str, seen_at: float) -> bool:
-        """Atomically advance ``last_seen`` for the matching API key."""
-        try:
-            client = self.get_client_by_api_key(api_key)
-            if client is None:
-                return False
-            return bool(
-                self.redis.eval(
-                    _ADVANCE_LAST_SEEN_LUA,
-                    1,
-                    self._client_key(client.client_id),
-                    api_key,
-                    float(seen_at),
-                    CREATE_MARKER,
-                )
-            )
-        except Exception as e:
-            LOG.error(f"Failed to update last_seen for client '{api_key}': {e}")
             return False
 
     def get_client_by_id(self, client_id: int) -> Optional[Client]:

--- a/tests/test_redisdb.py
+++ b/tests/test_redisdb.py
@@ -102,18 +102,6 @@ class FakeRedis:
     def ping(self):
         return True
 
-    def eval(self, _script, numkeys, key, api_key, seen_at, create_marker):
-        assert numkeys == 1
-        raw = self.get(key)
-        if not raw or raw == create_marker:
-            return 0
-        client = json.loads(raw)
-        if client.get("api_key") != api_key:
-            return 0
-        client["last_seen"] = max(float(client.get("last_seen", -1)), float(seen_at))
-        self.set(key, json.dumps(client))
-        return 1
-
 
 class FakePipeline:
     def __init__(self, redis_client):
@@ -479,33 +467,6 @@ class RedisDBTests(unittest.TestCase):
 
         self.assertIsNone(found)
         self.assertEqual(redis_client.scan_count, 0)
-
-    def test_update_last_seen_never_moves_timestamp_backward(self):
-        redis_client = FakeRedis()
-        db = self.build_db(redis_client)
-        client = Client(client_id=1, api_key="alpha-key", name="alpha", last_seen=200.0)
-        self.assertTrue(db.add_item(client))
-
-        self.assertTrue(db.update_last_seen("alpha-key", 100.0))
-        self.assertEqual(db.get_client_by_api_key("alpha-key").last_seen, 200.0)
-
-        self.assertTrue(db.update_last_seen("alpha-key", 300.0))
-        self.assertEqual(db.get_client_by_api_key("alpha-key").last_seen, 300.0)
-
-    def test_update_last_seen_rejects_missing_or_reassigned_api_key(self):
-        redis_client = FakeRedis()
-        db = self.build_db(redis_client)
-        client = Client(client_id=1, api_key="alpha-key", name="alpha")
-        self.assertTrue(db.add_item(client))
-
-        self.assertFalse(db.update_last_seen("missing-key", 100.0))
-
-        redis_client.storage["client:client:1"] = Client(
-            client_id=1,
-            api_key="replacement-key",
-            name="alpha",
-        ).serialize()
-        self.assertFalse(db.update_last_seen("alpha-key", 100.0))
 
     def test_search_by_api_key_does_not_scan_on_index_miss(self):
         redis_client = FakeRedis()

--- a/tests/test_redisdb.py
+++ b/tests/test_redisdb.py
@@ -25,7 +25,6 @@ class FakeRedis:
         self.connection_pool = Mock()
         self.pipeline_transaction_flags = []
         self.mget_calls = []
-        self.scan_count = 0
 
     def exists(self, key):
         return key in self.storage or key in self.hashes
@@ -89,7 +88,6 @@ class FakeRedis:
         return 1
 
     def scan_iter(self, pattern, count=None):
-        self.scan_count += 1
         del count
         for key in sorted(set(self.storage) | set(self.hashes)):
             if fnmatch(key, pattern):
@@ -297,29 +295,6 @@ class RedisDBTests(unittest.TestCase):
         self.assertEqual(ssl_kwargs["ssl_cert_reqs"], "none")
         self.assertFalse(ssl_kwargs["ssl_check_hostname"])
 
-    @patch("hivemind_redis_database.redis.StrictRedis")
-    def test_create_single_connection_uses_configured_pool_size(self, strict_redis):
-        db = object.__new__(RedisDB)
-        db.host = "redis.example.com"
-        db.port = 6379
-        db.db = 0
-        db.password = "secret"
-        db.username = "default"
-        db.max_connections = 64
-        db.retry_attempts = 3
-        db.retry_delay = 0.1
-        db.use_ssl = False
-        db.ssl_certfile = None
-        db.ssl_keyfile = None
-        db.ssl_ca_certs = None
-        db.ssl_cert_reqs = "required"
-        db.ssl_check_hostname = True
-
-        db._create_single_connection()
-
-        strict_redis.assert_called_once()
-        self.assertEqual(strict_redis.call_args.kwargs["max_connections"], 64)
-
     @patch("hivemind_redis_database.redis.RedisCluster")
     def test_create_cluster_connection_uses_retry_policy(self, redis_cluster):
         db = object.__new__(RedisDB)
@@ -440,47 +415,6 @@ class RedisDBTests(unittest.TestCase):
 
         self.assertEqual(len(found), 1)
         self.assertEqual(found[0].metadata, {"owner_id": "owner-123"})
-
-    def test_get_client_by_api_key_uses_secondary_index(self):
-        redis_client = FakeRedis()
-        db = self.build_db(redis_client)
-
-        client = Client(client_id=1, api_key="alpha-key", name="alpha")
-        self.assertTrue(db.add_item(client))
-
-        found = db.get_client_by_api_key("alpha-key")
-
-        self.assertIsNotNone(found)
-        self.assertEqual(found.client_id, 1)
-        self.assertEqual(redis_client.mget_calls[-1], ["client:client:1"])
-
-    def test_get_client_by_api_key_does_not_scan_on_index_miss(self):
-        redis_client = FakeRedis()
-        db = self.build_db(redis_client)
-        redis_client.storage["client:client:1"] = Client(
-            client_id=1,
-            api_key="alpha-key",
-            name="alpha",
-        ).serialize()
-
-        found = db.get_client_by_api_key("alpha-key")
-
-        self.assertIsNone(found)
-        self.assertEqual(redis_client.scan_count, 0)
-
-    def test_search_by_api_key_does_not_scan_on_index_miss(self):
-        redis_client = FakeRedis()
-        db = self.build_db(redis_client)
-        redis_client.storage["client:client:1"] = Client(
-            client_id=1,
-            api_key="alpha-key",
-            name="alpha",
-        ).serialize()
-
-        found = db.search_by_value("api_key", "alpha-key")
-
-        self.assertEqual(found, [])
-        self.assertEqual(redis_client.scan_count, 0)
 
     def test_client_metadata_survives_sync(self):
         redis_client = FakeRedis()
@@ -777,6 +711,7 @@ class TestRedisDBRefresh(unittest.TestCase):
         db.redisearch_available = False
         fake.storage["client:client:5"] = "__hivemind_creating__"
         self.assertIsNone(db.refresh(5))
+
 
 class TestRedisDBPipelineTransactional(unittest.TestCase):
     """Single-node Redis must use transactional pipelines so add_item /


### PR DESCRIPTION
Reverts three PRs merged to `dev` by an automated coding agent that should not have had merge access.

- **#33** (`ci: release safely after fork merges`) switched the release workflow to `pull_request_target` (trusted token + secrets on fork-PR events); it then fired and auto-published `0.1.0a5` to PyPI without review. Reverted → trigger back to `pull_request`; the remaining `pull_request_target` is the pre-existing label-only workflow.
- **#32** (`advance last_seen atomically`) and **#31** (`indexed API-key lookup + larger Redis pool`) reverted as unauthorized functional changes.

Tests green on the reverted tree (55 passed). Published PyPI alpha left in place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)