### PR TITLE
docs: rewrite README in Simplified Technical English

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 Redis-backed client database plugin for [hivemind-core](https://github.com/JarbasHiveMind/HiveMind-core).
 
-Implements the [`hivemind-plugin-manager`](https://github.com/JarbasHiveMind/hivemind-plugin-manager)
-`AbstractDB` contract on top of Redis. Suitable for multi-host fleets, high-availability setups,
-and deployments where the database must be shared across multiple hivemind-core processes.
+This plugin implements the [`hivemind-plugin-manager`](https://github.com/JarbasHiveMind/hivemind-plugin-manager)
+`AbstractDB` contract on top of Redis. Use it for multi-host fleets, high-availability setups,
+and deployments where several hivemind-core processes share one database.
 
 It supports:
 
@@ -12,7 +12,7 @@ It supports:
 - Redis Cluster
 - optional TLS
 - optional RediSearch / Redis Stack acceleration
-- transactional same-slot writes in cluster mode via `cluster_hash_tag`
+- transactional same-slot writes in cluster mode through `cluster_hash_tag`
 - repair and migration tooling for production rollouts
 
 ## Why This Backend
@@ -26,7 +26,7 @@ Key operational points:
   at a live node
 - it uses RediSearch when the module is available, and falls back to normal
   Redis indexing when it is not
-- it keeps exact-match search semantics even when RediSearch is enabled
+- it keeps exact-match search semantics whether or not RediSearch is enabled
 - it hides revoked clients from iteration and search results
 - it exposes `sync()` to rebuild counters, set indexes, and search hashes after
   interrupted writes or manual Redis changes
@@ -42,22 +42,22 @@ Compatibility:
 - Python 3.10+
 - Redis for single-instance mode
 - Redis Cluster for cluster mode
-- Redis Stack or Redis with the RediSearch module loaded for advanced search
+- Redis Stack, or Redis with the RediSearch module loaded, for advanced search
 
 ## Deployment Modes
 
 | Mode | Use when | Notes |
 | --- | --- | --- |
 | Single Redis | You want the simplest production setup | Supports `db`, TLS, RediSearch, and normal Redis indexing |
-| Redis Cluster, legacy mode | You already have an existing cluster namespace | Compatible with current key layout; primary records remain authoritative and `name` / `api_key` search falls back to scans |
+| Redis Cluster, legacy mode | You already have an existing cluster namespace | Compatible with the current key layout; primary records stay authoritative and `name` / `api_key` search falls back to scans |
 | Redis Cluster with `cluster_hash_tag` | New cluster deployments | Recommended mode; keeps all keys for one namespace in one slot and enables transactional cluster pipelines |
 | Redis Stack / RediSearch | You want faster indexed search on `name` and `api_key` | Optional; fallback indexing still works without it |
 
 Recommendation:
 
-- single Redis deployments: straightforward upgrade, no migration needed
+- single Redis deployments: upgrade directly, no migration needed
 - new Redis Cluster deployments: enable `cluster_hash_tag` from day one
-- existing Redis Cluster deployments: upgrade safely on the legacy namespace if
+- existing Redis Cluster deployments: upgrade the legacy namespace first if
   needed, then migrate to `cluster_hash_tag` in a maintenance window
 
 ## HiveMind-core Configuration
@@ -68,9 +68,9 @@ through directly.
 Important note:
 
 - `name` and `subfolder` are part of the HiveMind-core database contract
-- `index_prefix` controls the actual Redis key namespace used by this backend
-- `subfolder` is accepted for compatibility, but it does not affect Redis keys
-  or data layout in this backend
+- `index_prefix` controls the actual Redis key namespace this backend uses
+- this backend accepts `subfolder` for compatibility, but it does not affect
+  Redis keys or data layout
 
 ### Single Redis
 
@@ -137,7 +137,7 @@ If you are staying on legacy cluster mode temporarily, omit
 }
 ```
 
-`ssl` is still accepted as a backward-compatible alias, but `use_ssl` is the
+`ssl` still works as a backward-compatible alias, but `use_ssl` is the
 preferred config key in new docs and new deployments.
 
 If your HiveMind-core config already includes `subfolder`, you can leave it
@@ -154,7 +154,7 @@ there. This backend accepts it, but does not use it for Redis namespacing.
 | `db` | Redis DB number for single-node mode | Default: `0`; ignored in cluster mode |
 | `username` | Redis ACL username | Default: `"default"` |
 | `password` | Redis password | Optional |
-| `index_prefix` | Actual Redis namespace prefix used by this backend | Default: `"client"` |
+| `index_prefix` | Actual Redis namespace prefix this backend uses | Default: `"client"` |
 | `cluster_nodes` | Explicit Redis Cluster startup nodes | Accepts the documented `[{\"host\": ..., \"port\": ...}]` shape |
 | `cluster_hash_tag` | Fixed hash tag for one-slot transactional writes in cluster mode | Recommended for new cluster deployments |
 | `max_connections` | Redis connection pool size | Default: `5` |
@@ -176,9 +176,9 @@ there. This backend accepts it, but does not use it for Redis namespacing.
 - In legacy Redis Cluster mode without `cluster_hash_tag`, the backend treats
   primary client records as authoritative and falls back to scan-based search
   for correctness.
-- Search remains exact-match. RediSearch is used as an accelerator, not as fuzzy
+- Search stays exact-match. RediSearch works as an accelerator, not as fuzzy
   search.
-- Revoked clients are excluded from iteration and search results so HiveMind
+- Revoked clients are excluded from iteration and search results, so HiveMind
   admin flows only see active clients.
 - `sync()` repairs drift by rebuilding counters, Redis set indexes, and
   RediSearch hash documents from stored client records.
@@ -234,7 +234,7 @@ Safe rollout:
 3. Run a dry run to confirm the source and target namespaces.
 4. Run the migration tool to copy records into the tagged namespace.
 5. Update `server.json` to set `cluster_hash_tag`.
-6. Restart HiveMind and smoke-test add, get, update, revoke, and search flows.
+6. Restart HiveMind and test the add, get, update, revoke, and search flows.
 7. Keep the legacy namespace for rollback until the new deployment is stable.
 
 Dry run:
@@ -258,20 +258,20 @@ hivemind-redis-migrate-cluster \
 Notes:
 
 - `--clear-target` clears keys in the target namespace before copying
-- `--source-cluster-hash-tag` is available if you are migrating from one tagged
-  namespace to another
-- the migration tool copies raw client records and then runs `sync()` on the
+- `--source-cluster-hash-tag` lets you migrate from one tagged namespace to
+  another
+- the migration tool copies raw client records, then runs `sync()` on the
   target namespace
 
-More detail is in [docs/cluster_consistency.md](docs/cluster_consistency.md).
+See [docs/cluster_consistency.md](docs/cluster_consistency.md) for more detail.
 
 Legacy Redis Cluster note:
 
-- this mode is now correctness-first rather than index-first
+- this mode is correctness-first rather than index-first
 - primary client records are written directly
 - `name` / `api_key` searches fall back to scans
 - RediSearch acceleration is disabled
-- `cluster_hash_tag` remains the recommended production mode for indexed,
+- `cluster_hash_tag` stays the recommended production mode for indexed,
   transactional cluster behavior
 
 ## Where it fits
@@ -285,6 +285,12 @@ hivemind-core
 
 The plugin registers under the `hivemind.database` entry-point group as
 `hivemind-redis-db-plugin`.
+
+## Related Projects
+
+- [hivemind-core](https://github.com/JarbasHiveMind/HiveMind-core): the HiveMind server that loads this plugin
+- [hivemind-plugin-manager](https://github.com/JarbasHiveMind/hivemind-plugin-manager): defines the `AbstractDB` contract this plugin implements
+- [hivemind-sqlite-database](https://github.com/JarbasHiveMind/hivemind-sqlite-database): a sibling database plugin, and the source for the plugin-authoring guide
 
 ## Docs
 
@@ -309,3 +315,7 @@ CI covers:
 - TLS Redis integration
 - Redis Cluster integration
 - Redis Stack Cluster integration
+
+## License
+
+See [LICENSE](LICENSE).

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -11,9 +11,9 @@ hivemind_plugin_manager.database.AbstractDB   (abstract)
                 └─ redis.cluster.RedisCluster (cluster mode)
 ```
 
-`RedisDB` auto-detects single-node vs. cluster by trying a `CLUSTER INFO`
-command after connecting. If the node reports `cluster_enabled:1`, it switches
-to `RedisCluster`.
+`RedisDB` auto-detects single-node vs. cluster mode. It tries a `CLUSTER INFO`
+command after connecting. If the node reports `cluster_enabled:1`, `RedisDB`
+switches to `RedisCluster`.
 
 ## Key schema
 
@@ -43,33 +43,33 @@ client:{clients}:count
 client:{clients}:id_seq
 ```
 
-The hash tag forces all keys into the same hash slot, enabling
+The hash tag forces all keys into the same hash slot. This enables
 `RedisCluster.pipeline(transaction=True)` for atomic multi-key writes.
 
 ## RediSearch acceleration
 
 When the RediSearch module is loaded (`MODULE LIST` returns a module named
-`search`), `RedisDB` creates a secondary FT index over the hash records and
+`search`), `RedisDB` creates a secondary FT index over the hash records. It
 uses `FT.SEARCH` for `search_by_value("name", ...)` and
 `search_by_value("api_key", ...)`.
 
-Without RediSearch the backend falls back to Redis set-index lookups. Either
-way, search remains **exact-match** — RediSearch is used as an accelerator,
-not for full-text or fuzzy queries.
+Without RediSearch, the backend falls back to Redis set-index lookups. Either
+way, search stays exact-match. RediSearch works as an accelerator, not for
+full-text or fuzzy queries.
 
 ## sync()
 
 `sync()` rebuilds the derived keys (counters, set indexes, RediSearch hash
 documents) from the authoritative `<prefix>:client:<id>` hash records. It is
-a recovery tool, not a transaction boundary — use it after interrupted writes
+a recovery tool, not a transaction boundary. Use it after interrupted writes
 or manual Redis changes.
 
 ## Schema migration
 
-`hivemind-plugin-manager`'s `AbstractDB.migrate()` contract is implemented but
-the Redis backend does not track a persistent schema version on disk (there is
-no SQLite `PRAGMA user_version` equivalent). Migrations are handled at the
-application level.
+`hivemind-plugin-manager`'s `AbstractDB.migrate()` contract is implemented,
+but the Redis backend does not track a persistent schema version on disk
+(there is no SQLite `PRAGMA user_version` equivalent). Migrations happen at
+the application level.
 
 For Redis Cluster migrations (moving from the legacy untagged key layout to
 the `cluster_hash_tag` layout), use the provided CLI tool:
@@ -87,4 +87,7 @@ plan and rollback procedure.
 
 See [hivemind-sqlite-database: authoring a plugin](https://github.com/JarbasHiveMind/hivemind-sqlite-database/blob/dev/docs/operations.md#authoring-a-database-backend-plugin)
 for the `AbstractDB` contract and `pyproject.toml` entry-point registration pattern.
-The contract is the same regardless of which storage technology you use underneath.
+The contract stays the same regardless of the storage technology underneath.
+
+---
+[Home](../README.md) · [Configuration →](configuration.md)

--- a/docs/cluster_consistency.md
+++ b/docs/cluster_consistency.md
@@ -12,15 +12,15 @@ This backend stores one logical client across multiple Redis keys:
 - `client:id_seq`
 
 In Redis Cluster, those keys map to different hash slots by default. Legacy
-cluster mode therefore works, but multi-key writes are not atomic. A failure in
+cluster mode still works, but multi-key writes are not atomic. A failure in
 the middle of `add_item()`, `update_client()`, or `remove_client()` can leave
 indexes or counters temporarily inconsistent.
 
-The backend now has `sync()` to repair drift, but `sync()` is a recovery tool,
-not a transaction boundary.
+`sync()` repairs this drift, but it is a recovery tool, not a transaction
+boundary.
 
-The backend now also supports an optional `cluster_hash_tag` setting. When
-enabled, all keys for that namespace are stored in the same Redis Cluster slot
+The backend also supports an optional `cluster_hash_tag` setting. When
+enabled, all keys for a namespace are stored in the same Redis Cluster slot
 and writes use `RedisCluster.pipeline(transaction=True)`.
 
 ## Smallest Safe Production Migration
@@ -39,16 +39,16 @@ for cluster deployments:
 3. In cluster mode with that tag enabled, the backend uses `RedisCluster.pipeline(transaction=True)`.
 
 Because every key shares the same hash tag, all commands map to the same slot.
-That is the minimum change that allows real Redis Cluster transactions for this
-schema.
+That is the minimum change that allows real Redis Cluster transactions for
+this schema.
 
 ## Why This Is The Right Tradeoff
 
-- The client database is small and metadata-heavy. It does not benefit much from
+- The client database is small and metadata-heavy. It gains little from
   distributing individual index keys across shards.
 - A single-slot namespace keeps the existing schema and query model.
-- The application gets actual atomic updates in cluster mode without inventing a
-  more complex write protocol.
+- The application gets real atomic updates in cluster mode without a more
+  complex write protocol.
 - Recovery and rollback stay simple.
 
 ## Recommended Rollout
@@ -66,7 +66,7 @@ schema.
 
 ## Migration Tool
 
-This repository now ships a helper command:
+This repository ships a helper command:
 
 ```bash
 hivemind-redis-migrate-cluster \
@@ -82,18 +82,22 @@ What it does:
 - skips stale in-progress create markers
 - runs `sync()` on the target namespace to rebuild indexes, counters, and search hashes
 
-Use `--dry-run` first if you want to inspect the plan without writing data.
+Use `--dry-run` first to inspect the plan without writing data.
 
 ## What Not To Do
 
 - Do not try to fake atomicity across cluster slots with ordinary pipelines.
-- Do not use distributed locks here unless there is a much stronger consistency
-  requirement; that adds operational complexity without solving the schema issue.
+- Do not use distributed locks here unless you have a much stronger
+  consistency requirement. Locks add operational complexity without solving
+  the schema issue.
 - Do not switch the default key format in place. That would silently orphan
   existing data.
 
 ## Practical Recommendation
 
 For new cluster deployments, enable `cluster_hash_tag` from the start.
-For existing cluster deployments, migrate deliberately and keep `sync()` as the
-repair path during rollout.
+For existing cluster deployments, migrate deliberately and keep `sync()` as
+the repair path during rollout.
+
+---
+[← Configuration](configuration.md) · [Home](../README.md) · [Operations →](operations.md)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,6 +1,6 @@
 # Configuration Reference
 
-All settings are passed in the `hivemind-redis-db-plugin` block of
+Pass all settings in the `hivemind-redis-db-plugin` block of
 `~/.config/hivemind-core/server.json`.
 
 | Setting | Default | Description |
@@ -9,21 +9,21 @@ All settings are passed in the `hivemind-redis-db-plugin` block of
 | `subfolder` | `"hivemind-core"` | HiveMind-core database contract field. Not used for Redis key naming. |
 | `host` | `"127.0.0.1"` | Redis host for single-node mode. |
 | `port` | `6379` | Redis port. |
-| `db` | `0` | Redis DB number (single-node only; ignored in cluster mode). |
+| `db` | `0` | Redis DB number (single-node only. Ignored in cluster mode). |
 | `username` | `"default"` | Redis ACL username. |
-| `password` | — | Redis password. |
+| `password` | none | Redis password. |
 | `index_prefix` | `"client"` | Key namespace prefix used inside Redis. |
-| `cluster_nodes` | — | List of `{"host": ..., "port": ...}` dicts for Redis Cluster startup. Presence triggers cluster mode. |
-| `cluster_hash_tag` | — | Fixed hash tag for one-slot transactional writes. Recommended for new cluster deployments. |
+| `cluster_nodes` | none | List of `{"host": ..., "port": ...}` dicts for Redis Cluster startup. Presence triggers cluster mode. |
+| `cluster_hash_tag` | none | Fixed hash tag for one-slot transactional writes. Recommended for new cluster deployments. |
 | `max_connections` | `5` | Redis connection pool size. |
 | `retry_attempts` | `3` | Internal retry count for transient operations. |
 | `retry_delay` | `0.1` | Seconds between retry attempts. |
 | `use_ssl` | `false` | Enable TLS. |
-| `ssl` | — | Backward-compatible alias for `use_ssl`. Prefer `use_ssl` in new configs. |
-| `ssl_certfile` | — | Path to client certificate (mTLS). |
-| `ssl_keyfile` | — | Path to client key (mTLS). |
-| `ssl_ca_certs` | — | Path to CA bundle. |
-| `ssl_cert_reqs` | — | TLS verification mode: `"required"`, `"optional"`, or `"none"`. |
+| `ssl` | none | Backward-compatible alias for `use_ssl`. Prefer `use_ssl` in new configs. |
+| `ssl_certfile` | none | Path to client certificate (mTLS). |
+| `ssl_keyfile` | none | Path to client key (mTLS). |
+| `ssl_ca_certs` | none | Path to CA bundle. |
+| `ssl_cert_reqs` | none | TLS verification mode: `"required"`, `"optional"`, or `"none"`. |
 | `ssl_check_hostname` | `true` | Hostname validation. Forced off when `ssl_cert_reqs="none"`. |
 
 ## Single Redis
@@ -90,3 +90,6 @@ transitional period. See [cluster_consistency.md](cluster_consistency.md).
   }
 }
 ```
+
+---
+[← Architecture](architecture.md) · [Home](../README.md) · [Cluster Consistency →](cluster_consistency.md)

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -3,7 +3,7 @@
 ## Backup
 
 The `hivemind-redis-migrate-cluster` CLI tool copies records between Redis
-namespaces and can be used for manual exports. For a full snapshot, use
+namespaces and works for manual exports too. For a full snapshot, use
 standard Redis persistence tools:
 
 ```bash
@@ -28,8 +28,8 @@ assert db.health_check()
 
 ## Repairing inconsistency
 
-If Redis indexes drift from the authoritative hash records (e.g. after an
-interrupted write or manual key deletion), run:
+If Redis indexes drift from the authoritative hash records (for example after
+an interrupted write or a manual key deletion), run:
 
 ```python
 db.sync()
@@ -58,3 +58,6 @@ Then update `server.json` to set `database.module` to `hivemind-redis-db-plugin`
 
 See [hivemind-sqlite-database: authoring a plugin](https://github.com/JarbasHiveMind/hivemind-sqlite-database/blob/dev/docs/operations.md#authoring-a-database-backend-plugin)
 for the `AbstractDB` contract and entry-point registration pattern.
+
+---
+[← Cluster Consistency](cluster_consistency.md) · [Home](../README.md)


### PR DESCRIPTION
Rewrites README.md and the four docs/*.md pages for clarity, tightening sentence length, verb choice, and removing hedges while keeping every fact, code block, and config example unchanged. Adds a related-projects section to the README and relative navigation footers across the docs pages.

Rewritten by Claude Sonnet 5 using the ste-writing skill (authored and reviewed by Claude Fable 5); linted with ste_lint.py.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified Redis Cluster behavior, including tagged-key transactions, legacy consistency, recovery, and migration options.
  * Documented exact-match search behavior, deployment recommendations, configuration settings, TLS, and cluster options.
  * Improved operational guidance for exports and repairing inconsistencies.
  * Added navigation links, related projects, and licensing information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->