### PR TITLE
fix: raise default Redis connection pool size from 5 to 50

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ there. This backend accepts it, but does not use it for Redis namespacing.
 | `index_prefix` | Actual Redis namespace prefix this backend uses | Default: `"client"` |
 | `cluster_nodes` | Explicit Redis Cluster startup nodes | Accepts the documented `[{\"host\": ..., \"port\": ...}]` shape |
 | `cluster_hash_tag` | Fixed hash tag for one-slot transactional writes in cluster mode | Recommended for new cluster deployments |
-| `max_connections` | Redis connection pool size | Default: `5` |
+| `max_connections` | Redis connection pool size | Default: `50` |
 | `retry_attempts` | Internal retry attempts for transient operations | Default: `3` |
 | `retry_delay` | Delay between retry attempts | Default: `0.1` seconds |
 | `use_ssl` | Enable TLS | Default: `false` |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -15,7 +15,7 @@ Pass all settings in the `hivemind-redis-db-plugin` block of
 | `index_prefix` | `"client"` | Key namespace prefix used inside Redis. |
 | `cluster_nodes` | none | List of `{"host": ..., "port": ...}` dicts for Redis Cluster startup. Presence triggers cluster mode. |
 | `cluster_hash_tag` | none | Fixed hash tag for one-slot transactional writes. Recommended for new cluster deployments. |
-| `max_connections` | `5` | Redis connection pool size. |
+| `max_connections` | `50` | Redis connection pool size. Every client connect and every message does a DB round trip, so the default is sized for real load, not a smoke test; raise it further for large deployments. |
 | `retry_attempts` | `3` | Internal retry count for transient operations. |
 | `retry_delay` | `0.1` | Seconds between retry attempts. |
 | `use_ssl` | `false` | Enable TLS. |

--- a/hivemind_redis_database/__init__.py
+++ b/hivemind_redis_database/__init__.py
@@ -54,7 +54,7 @@ class RedisDB(AbstractRemoteDB):
         cluster_nodes (Optional[List[dict]]): Redis Cluster node configuration
         cluster_hash_tag (Optional[str]): Fixed Redis Cluster hash tag for single-slot writes
         index_prefix (str): Key prefix for all database operations (default: "client")
-        max_connections (int): Maximum connection pool size (default: 5)
+        max_connections (int): Maximum connection pool size (default: 50)
         retry_attempts (int): Number of retry attempts (default: 3)
         retry_delay (float): Delay between retry attempts in seconds (default: 0.1)
         use_ssl (bool): Enable SSL/TLS connection (default: False)
@@ -73,7 +73,7 @@ class RedisDB(AbstractRemoteDB):
     cluster_nodes: Optional[List[dict]] = None
     cluster_hash_tag: Optional[str] = None
     index_prefix: str = "client"
-    max_connections: int = 5
+    max_connections: int = 50
     retry_attempts: int = 3
     retry_delay: float = 0.1
     use_ssl: bool = False

--- a/tests/test_redisdb.py
+++ b/tests/test_redisdb.py
@@ -201,6 +201,7 @@ class RedisDBTests(unittest.TestCase):
         self.assertEqual(db.host, "127.0.0.1")
         self.assertEqual(db.port, 6379)
         self.assertEqual(db.subfolder, "hivemind-core")
+        self.assertEqual(db.max_connections, 50)
 
     def test_ssl_alias_is_accepted(self):
         fake_redis = FakeRedis()


### PR DESCRIPTION
## Summary
- `RedisDB.max_connections` defaulted to 5. Redis is the recommended backend at scale (see hivemind-core docs merged as PR #203), and every client connect plus every message does a DB round trip against it. A pool of 5 queues under any real load.
- Raised the default to 50 (dataclass field, docstring, README.md, docs/configuration.md all updated).

## Test plan
- [x] Added assertion `db.max_connections == 50` to `test_database_factory_defaults_are_normalized`
- [x] `~/.venvs/ovos/bin/python -m pytest tests -q -p no:ovoscope -p no:recording --timeout=600` — 57 passed, 6 skipped

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Increased the default Redis connection pool size from 5 to 50.

- **Documentation**
  - Updated configuration guidance to explain connection usage and scaling considerations.

- **Tests**
  - Added coverage confirming the new default connection pool size.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->