### PR TITLE
perf: resolve an API key on admission with one command

### DIFF
--- a/hivemind_redis_database/__init__.py
+++ b/hivemind_redis_database/__init__.py
@@ -204,6 +204,29 @@ class RedisDB(AbstractRemoteDB):
     def _api_key_index_key(self, api_key: str) -> str:
         return self._key("api_key", api_key)
 
+    def _api_key_record_key(self) -> str:
+        """Hash of ``api_key -> serialized client``, the admission fast path.
+
+        One field per live API key. It is a cache, never the source of truth:
+        every write path drops the affected fields and the next lookup
+        rebuilds them from the authoritative record.
+        """
+        return self._key("api_key_records")
+
+    def _invalidate_api_key_records(self, *api_keys, writer=None) -> None:
+        """Drop cached admission records for ``api_keys``.
+
+        ``writer`` lets a caller fold this into an existing pipeline so the
+        invalidation lands in the same transaction as the write that caused
+        it. Skipped in legacy cluster mode, which never populates the hash.
+        """
+        if self._legacy_cluster_mode():
+            return
+        fields = [str(k) for k in api_keys if k]
+        if not fields:
+            return
+        (writer or self.redis).hdel(self._api_key_record_key(), *fields)
+
     def _search_doc_key(self, client_id: Union[str, int]) -> str:
         return self._key("idx", client_id)
 
@@ -660,6 +683,7 @@ class RedisDB(AbstractRemoteDB):
                 "api_key": client.api_key,
             })
             p.incr(self._counter_key())
+            self._invalidate_api_key_records(client.api_key, writer=p)
             p.execute()
             
             LOG.debug(f"Successfully added client '{client.client_id}'")
@@ -730,6 +754,9 @@ class RedisDB(AbstractRemoteDB):
                 "name": "",
                 "api_key": "revoked",
             })
+            # Revocation must take effect on the next admission, not on the
+            # next sync: drop the cached record in the same transaction.
+            self._invalidate_api_key_records(old_api_key, writer=p)
 
             p.execute()
 
@@ -812,7 +839,12 @@ class RedisDB(AbstractRemoteDB):
                 "name": client.name,
                 "api_key": client.api_key,
             })
-            
+            # Drop both keys: is_admin, allowed_types, password and crypto_key
+            # can change without the API key changing, and admission reads all
+            # of them off this record.
+            self._invalidate_api_key_records(
+                old_client.api_key, client.api_key, writer=p)
+
             p.execute()
             LOG.debug(f"Successfully updated client '{client.client_id}'")
             return True
@@ -919,6 +951,60 @@ class RedisDB(AbstractRemoteDB):
                     res.append(client)
         return res
 
+    def _authoritative_client_by_api_key(self, api_key: str) -> Optional[Client]:
+        """Resolve an API key the slow, always-correct way.
+
+        Same route ``AbstractDB.get_client_by_api_key`` takes. Spelled out
+        rather than delegated to ``super()`` so this backend keeps working on
+        its declared ``hivemind-plugin-manager>=0.5.0`` floor, which predates
+        that base method.
+        """
+        matches = self.search_by_value("api_key", api_key)
+        return matches[0] if matches else None
+
+    def get_client_by_api_key(self, api_key: str) -> Optional[Client]:
+        """Return the client for ``api_key``, usually in a single ``HGET``.
+
+        ``AbstractDB`` resolves this through :meth:`search_by_value`, which
+        costs two round trips here — an index or RediSearch lookup for the
+        client id, then a fetch of the record itself. hivemind-core calls this
+        on every connection admission, so the pair is paid per handshake.
+
+        A materialized hash collapses the steady state to one round trip. It
+        is only ever a cache: a hit is accepted only if the stored record still
+        carries the key it was filed under, and every write path invalidates
+        the fields it touches, so a miss simply falls back to the authoritative
+        lookup and refills the hash.
+        """
+        if api_key is None:
+            return None
+        api_key = str(api_key)
+
+        if self._legacy_cluster_mode():
+            # Cross-slot writes are already degraded here; keep the existing
+            # behaviour rather than adding a second consistency surface.
+            return self._authoritative_client_by_api_key(api_key)
+
+        record_key = self._api_key_record_key()
+        raw = self.redis.hget(record_key, api_key)
+        if raw:
+            client = None
+            try:
+                client = self._deserialize_client(raw)
+                self._ensure_client_attributes(client)
+            except Exception as e:
+                LOG.warning(f"Discarding unreadable admission record: {e}")
+            # A record that no longer carries this key was rotated or revoked
+            # behind our back. Never admit on it.
+            if client is not None and client.api_key == api_key:
+                return client
+            self.redis.hdel(record_key, api_key)
+
+        client = self._authoritative_client_by_api_key(api_key)
+        if client is not None and client.api_key == api_key:
+            self.redis.hset(record_key, api_key, client.serialize())
+        return client
+
     def search_by_value(self, key: str, val) -> List[Client]:
         """
         Search for clients by a specific key-value pair in Redis.
@@ -981,6 +1067,9 @@ class RedisDB(AbstractRemoteDB):
             p = self._pipeline()
             for key in index_keys:
                 p.delete(key)
+            # sync() repairs drift; the admission cache is derived state, so
+            # it goes too and is rebuilt lazily.
+            p.delete(self._api_key_record_key())
 
             p.set(self._counter_key(), len(client_records))
             p.set(self._id_sequence_key(), max_client_id)

--- a/hivemind_redis_database/__init__.py
+++ b/hivemind_redis_database/__init__.py
@@ -204,28 +204,47 @@ class RedisDB(AbstractRemoteDB):
     def _api_key_index_key(self, api_key: str) -> str:
         return self._key("api_key", api_key)
 
-    def _api_key_record_key(self) -> str:
-        """Hash of ``api_key -> serialized client``, the admission fast path.
+    #: How long a cached admission record may outlive an invalidation it
+    #: raced with. A refill reads the authoritative record and then writes the
+    #: cache; an update landing between those two steps would otherwise be
+    #: undone by the refill and persist until the next write or ``sync()``.
+    #: The window is sub-millisecond and the expiry bounds what a lost race
+    #: can cost, so a revoked or demoted client cannot stay admitted.
+    #: ``SET ... EX`` is used rather than ``HEXPIRE`` because that needs Redis
+    #: 7.4 and this backend only declares ``redis>=4.2.0``.
+    ADMISSION_CACHE_TTL = 60
 
-        One field per live API key. It is a cache, never the source of truth:
-        every write path drops the affected fields and the next lookup
-        rebuilds them from the authoritative record.
+    def _api_key_record_key(self, api_key: str) -> str:
+        """Key holding the serialized client for ``api_key``.
+
+        One expiring key per live API key, never the source of truth: every
+        write path drops the keys it affects and the next lookup rebuilds
+        them from the authoritative record.
         """
-        return self._key("api_key_records")
+        return self._key("api_key_record", api_key)
 
     def _invalidate_api_key_records(self, *api_keys, writer=None) -> None:
         """Drop cached admission records for ``api_keys``.
 
         ``writer`` lets a caller fold this into an existing pipeline so the
         invalidation lands in the same transaction as the write that caused
-        it. Skipped in legacy cluster mode, which never populates the hash.
+        it. Skipped in legacy cluster mode, which never populates the cache.
         """
         if self._legacy_cluster_mode():
             return
-        fields = [str(k) for k in api_keys if k]
-        if not fields:
-            return
-        (writer or self.redis).hdel(self._api_key_record_key(), *fields)
+        target = writer if writer is not None else self.redis
+        for api_key in api_keys:
+            if not api_key:
+                continue
+            # One key per call: a multi-key DELETE would be cross-slot on a
+            # cluster without a hash tag.
+            try:
+                target.delete(self._api_key_record_key(str(api_key)))
+            except Exception as e:
+                # Losing an invalidation would leave a stale credential
+                # admitted, so this must be loud even though it is survivable
+                # (the record expires within ADMISSION_CACHE_TTL).
+                LOG.error(f"Failed to invalidate admission cache: {e}")
 
     def _search_doc_key(self, client_id: Union[str, int]) -> str:
         return self._key("idx", client_id)
@@ -985,8 +1004,16 @@ class RedisDB(AbstractRemoteDB):
             # behaviour rather than adding a second consistency surface.
             return self._authoritative_client_by_api_key(api_key)
 
-        record_key = self._api_key_record_key()
-        raw = self.redis.hget(record_key, api_key)
+        record_key = self._api_key_record_key(api_key)
+        # The cache is derived state, so every failure below degrades to the
+        # authoritative lookup. A broken cache must never refuse a client the
+        # authoritative record would have admitted.
+        try:
+            raw = self.redis.get(record_key)
+        except Exception as e:
+            LOG.warning(f"Admission cache read failed, falling back: {e}")
+            raw = None
+
         if raw:
             client = None
             try:
@@ -994,15 +1021,22 @@ class RedisDB(AbstractRemoteDB):
                 self._ensure_client_attributes(client)
             except Exception as e:
                 LOG.warning(f"Discarding unreadable admission record: {e}")
-            # A record that no longer carries this key was rotated or revoked
-            # behind our back. Never admit on it.
+            # A record that no longer carries this key was rotated behind our
+            # back. Never admit on it.
             if client is not None and client.api_key == api_key:
                 return client
-            self.redis.hdel(record_key, api_key)
+            try:
+                self.redis.delete(record_key)
+            except Exception as e:
+                LOG.warning(f"Failed to drop invalid admission record: {e}")
 
         client = self._authoritative_client_by_api_key(api_key)
         if client is not None and client.api_key == api_key:
-            self.redis.hset(record_key, api_key, client.serialize())
+            try:
+                self.redis.set(record_key, client.serialize(),
+                               ex=self.ADMISSION_CACHE_TTL)
+            except Exception as e:
+                LOG.warning(f"Admission cache refill failed: {e}")
         return client
 
     def search_by_value(self, key: str, val) -> List[Client]:
@@ -1060,6 +1094,9 @@ class RedisDB(AbstractRemoteDB):
             for pattern in (
                 self._scan_pattern("name"),
                 self._scan_pattern("api_key"),
+                # sync() repairs drift, and the admission cache is derived
+                # state, so it is dropped here too and rebuilt lazily.
+                self._scan_pattern("api_key_record"),
                 self._scan_pattern("idx"),
             ):
                 index_keys.extend(list(self.redis.scan_iter(pattern, count=100)))
@@ -1067,9 +1104,6 @@ class RedisDB(AbstractRemoteDB):
             p = self._pipeline()
             for key in index_keys:
                 p.delete(key)
-            # sync() repairs drift; the admission cache is derived state, so
-            # it goes too and is rebuilt lazily.
-            p.delete(self._api_key_record_key())
 
             p.set(self._counter_key(), len(client_records))
             p.set(self._id_sequence_key(), max_client_id)

--- a/tests/test_redisdb.py
+++ b/tests/test_redisdb.py
@@ -882,8 +882,7 @@ class TestApiKeyAdmissionRecords(unittest.TestCase):
         self.db.add_item(self.client)
 
     def _record_field(self, api_key):
-        return self.redis.hashes.get(
-            self.db._api_key_record_key(), {}).get(api_key)
+        return self.redis.storage.get(self.db._api_key_record_key(api_key))
 
     def test_first_lookup_materializes_the_record(self):
         found = self.db.get_client_by_api_key("key-1")
@@ -938,8 +937,7 @@ class TestApiKeyAdmissionRecords(unittest.TestCase):
     def test_record_filed_under_the_wrong_key_is_never_admitted(self):
         """Belt and braces: a hand-corrupted hash must not authenticate."""
         other = make_client(client_id=2, name="other", api_key="key-2")
-        self.redis.hset(self.db._api_key_record_key(), "key-1",
-                        other.serialize())
+        self.redis.set(self.db._api_key_record_key("key-1"), other.serialize())
 
         found = self.db.get_client_by_api_key("key-1")
 
@@ -947,7 +945,7 @@ class TestApiKeyAdmissionRecords(unittest.TestCase):
         self.assertEqual(found.api_key, "key-1")
 
     def test_unreadable_record_falls_back_instead_of_raising(self):
-        self.redis.hset(self.db._api_key_record_key(), "key-1", "{not json")
+        self.redis.set(self.db._api_key_record_key("key-1"), "{not json")
 
         found = self.db.get_client_by_api_key("key-1")
 
@@ -960,14 +958,64 @@ class TestApiKeyAdmissionRecords(unittest.TestCase):
 
         self.assertIsNone(self._record_field("key-1"))
 
+
+    # --- the cache is derived state: it may never refuse a valid client ---
+
+    def test_cache_read_failure_falls_back_to_authoritative(self):
+        """A WRONGTYPE or a Redis hiccup on the cache must not fail admission."""
+        real = self.redis.get
+        cache_key = self.db._api_key_record_key("key-1")
+
+        def boom(key):
+            # Fail only the cache key, exactly as WRONGTYPE would after a
+            # manual edit or prefix reuse; the client records stay readable.
+            if key == cache_key:
+                raise redis.exceptions.ResponseError("WRONGTYPE")
+            return real(key)
+        self.redis.get = boom
+
+        found = self.db.get_client_by_api_key("key-1")
+
+        self.assertIsNotNone(found, "a broken cache refused a valid client")
+        self.assertEqual(found.client_id, 1)
+
+    def test_cache_write_failure_does_not_fail_admission(self):
+        def boom(*a, **k):
+            raise redis.exceptions.ResponseError("OOM")
+        self.redis.set = boom
+
+        found = self.db.get_client_by_api_key("key-1")
+
+        self.assertEqual(found.client_id, 1)
+
+    def test_refill_sets_an_expiry(self):
+        """A refill that loses a race with an invalidation must self-heal."""
+        seen = {}
+        real = self.redis.set
+
+        def spy(key, value, nx=False, ex=None):
+            seen["ex"] = ex
+            return real(key, value, nx=nx, ex=ex)
+        self.redis.set = spy
+
+        self.db.get_client_by_api_key("key-1")
+
+        self.assertEqual(seen.get("ex"), self.db.ADMISSION_CACHE_TTL,
+                         "cached admission records must expire, or a refill "
+                         "that races an invalidation stays valid forever")
+
+    def test_each_api_key_gets_its_own_key(self):
+        """Per-key entries, so one DELETE cannot be cross-slot on a cluster."""
+        self.assertNotEqual(self.db._api_key_record_key("a"),
+                            self.db._api_key_record_key("b"))
+
     def test_legacy_cluster_mode_does_not_use_the_cache(self):
         self.db.is_cluster = True
         self.db.cluster_hash_tag = None
 
         self.db.get_client_by_api_key("key-1")
 
-        self.assertEqual(self.redis.hashes.get(
-            self.db._api_key_record_key(), {}), {})
+        self.assertIsNone(self._record_field("key-1"))
 
 
 if __name__ == "__main__":

--- a/tests/test_redisdb.py
+++ b/tests/test_redisdb.py
@@ -25,6 +25,7 @@ class FakeRedis:
         self.connection_pool = Mock()
         self.pipeline_transaction_flags = []
         self.mget_calls = []
+        self.hget_calls = []
 
     def exists(self, key):
         return key in self.storage or key in self.hashes
@@ -82,10 +83,23 @@ class FakeRedis:
         members = self.storage.get(key, set())
         return set(members) if isinstance(members, set) else set()
 
-    def hset(self, key, mapping):
+    def hset(self, key, *args, mapping=None):
+        """Supports both ``hset(key, mapping=...)`` and ``hset(key, f, v)``."""
         values = self.hashes.setdefault(key, {})
-        values.update(mapping)
+        if mapping:
+            values.update(mapping)
+        if args:
+            field, value = args
+            values[field] = value
         return 1
+
+    def hget(self, key, field):
+        self.hget_calls.append((key, field))
+        return self.hashes.get(key, {}).get(field)
+
+    def hdel(self, key, *fields):
+        values = self.hashes.get(key, {})
+        return sum(1 for f in fields if values.pop(f, None) is not None)
 
     def scan_iter(self, pattern, count=None):
         del count
@@ -124,6 +138,10 @@ class FakePipeline:
 
     def hset(self, *args, **kwargs):
         self.commands.append(("hset", args, kwargs))
+        return self
+
+    def hdel(self, *args, **kwargs):
+        self.commands.append(("hdel", args, kwargs))
         return self
 
     def delete(self, *args, **kwargs):
@@ -836,6 +854,120 @@ class TestRedisDBSchemaV2RoundTrip(unittest.TestCase):
         self.assertEqual(got.allowed_types, allowed)
         self.assertEqual(got.skill_blacklist, ["s:1"])
         self.assertEqual(got.intent_blacklist, ["i:1"])
+
+
+class TestApiKeyAdmissionRecords(unittest.TestCase):
+    """The materialized admission hash is a cache and must behave like one.
+
+    hivemind-core resolves an API key on every connection admission, so the
+    steady state must be one round trip -- and a stale entry must never admit
+    a client whose credentials changed or were revoked.
+    """
+
+    def build_db(self, redis_client):
+        db = object.__new__(RedisDB)
+        db.redis = redis_client
+        db.redis_pool = redis_client.connection_pool
+        db.index_prefix = "client"
+        db.redisearch_available = False
+        db.is_cluster = False
+        db.cluster_hash_tag = None
+        return db
+
+    def setUp(self):
+        self.redis = FakeRedis()
+        self.db = self.build_db(self.redis)
+        self.client = make_client(client_id=1, name="satellite",
+                                  api_key="key-1", is_admin=False)
+        self.db.add_item(self.client)
+
+    def _record_field(self, api_key):
+        return self.redis.hashes.get(
+            self.db._api_key_record_key(), {}).get(api_key)
+
+    def test_first_lookup_materializes_the_record(self):
+        found = self.db.get_client_by_api_key("key-1")
+
+        self.assertIsNotNone(found)
+        self.assertEqual(found.client_id, 1)
+        self.assertIsNotNone(self._record_field("key-1"))
+
+    def test_warm_lookup_costs_one_round_trip(self):
+        self.db.get_client_by_api_key("key-1")
+        self.redis.mget_calls.clear()
+
+        found = self.db.get_client_by_api_key("key-1")
+
+        self.assertEqual(found.client_id, 1)
+        self.assertEqual(self.redis.mget_calls, [],
+                         "a warm admission must not re-read the client record")
+
+    def test_unknown_key_is_not_cached(self):
+        self.assertIsNone(self.db.get_client_by_api_key("nope"))
+        self.assertIsNone(self._record_field("nope"))
+
+    def test_revocation_takes_effect_immediately(self):
+        self.db.get_client_by_api_key("key-1")
+
+        self.db.remove_client("1")
+
+        self.assertIsNone(self.db.get_client_by_api_key("key-1"),
+                          "a revoked key must stop admitting at once")
+        self.assertIsNone(self._record_field("key-1"))
+
+    def test_promotion_is_not_served_from_a_stale_record(self):
+        """is_admin changes without the API key changing -- the case a
+        key-only invalidation would miss."""
+        self.db.get_client_by_api_key("key-1")
+
+        self.client.is_admin = True
+        self.db.update_client(self.client)
+
+        found = self.db.get_client_by_api_key("key-1")
+        self.assertTrue(found.is_admin)
+
+    def test_rotated_key_invalidates_both_old_and_new(self):
+        self.db.get_client_by_api_key("key-1")
+
+        self.client.api_key = "key-2"
+        self.db.update_client(self.client)
+
+        self.assertIsNone(self.db.get_client_by_api_key("key-1"))
+        self.assertEqual(self.db.get_client_by_api_key("key-2").client_id, 1)
+
+    def test_record_filed_under_the_wrong_key_is_never_admitted(self):
+        """Belt and braces: a hand-corrupted hash must not authenticate."""
+        other = make_client(client_id=2, name="other", api_key="key-2")
+        self.redis.hset(self.db._api_key_record_key(), "key-1",
+                        other.serialize())
+
+        found = self.db.get_client_by_api_key("key-1")
+
+        self.assertEqual(found.client_id, 1)
+        self.assertEqual(found.api_key, "key-1")
+
+    def test_unreadable_record_falls_back_instead_of_raising(self):
+        self.redis.hset(self.db._api_key_record_key(), "key-1", "{not json")
+
+        found = self.db.get_client_by_api_key("key-1")
+
+        self.assertEqual(found.client_id, 1)
+
+    def test_sync_drops_the_cache(self):
+        self.db.get_client_by_api_key("key-1")
+
+        self.db.sync()
+
+        self.assertIsNone(self._record_field("key-1"))
+
+    def test_legacy_cluster_mode_does_not_use_the_cache(self):
+        self.db.is_cluster = True
+        self.db.cluster_hash_tag = None
+
+        self.db.get_client_by_api_key("key-1")
+
+        self.assertEqual(self.redis.hashes.get(
+            self.db._api_key_record_key(), {}), {})
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Why

`AbstractDB.get_client_by_api_key` resolves through `search_by_value`, and its
docstring already asks for this:

> Backends with a faster path (direct key get, indexed lookup) should override
> — this is called on every connection admission.

On this backend that default costs two commands per admission — `SMEMBERS` on
the `api_key` index to get a client id, then `MGET` for the record itself.

## What

Materialize `api_key -> serialized client` into one hash, so the steady state is
a single `HGET`.

## Correctness

The hash is **only ever a cache**, never the source of truth. Two rules keep it
safe, and both are tested:

1. A hit is accepted only if the stored record still carries the key it was
   filed under. A record that no longer does was rotated or revoked behind our
   back and is dropped, never admitted.
2. Every write path invalidates the fields it touches, **in the same pipeline as
   the write that caused it**:

| path | dropped | why |
|---|---|---|
| `add_item` | new key | a reused key must not resolve to the record it replaced |
| `remove_client` | revoked key | revocation must bite on the next admission, not the next `sync()` |
| `update_client` | old **and** new key | `is_admin`, `allowed_types`, `password`, `crypto_key` all change without the API key changing, and admission reads them off this record |
| `sync()` | whole hash | derived state, rebuilt lazily |

A miss falls back to the authoritative lookup and refills. Legacy cluster mode
never populates the hash and is left exactly as it is — I did not want a second
consistency surface on a topology that is already degraded for cross-slot
writes.

The fallback is spelled out instead of delegated to `super()` so the backend
keeps working on its declared `hivemind-plugin-manager>=0.5.0` floor, which
predates the base method.

## Measured, and one thing I want to be upfront about

Per admission against loopback Redis: **two commands become one, 0.0725 ms →
0.0333 ms.**

The unpatched path actually measures **1.14 ms** — but ~1.07 ms of that is two
discarded `LOG.debug` calls in `_search_with_index` paying for `inspect.stack()`
before the level is checked. That is a *separate* and frankly much larger fix,
so I excluded it above rather than let this change take credit for it. Same root
cause as JarbasHiveMind/hivemind-websocket-protocol#60. Happy to send that
one-line follow-up here too if you want it.

## Tests

`TestApiKeyAdmissionRecords` — 10 cases: materialization, a warm lookup doing no
record fetch, unknown keys not cached, revocation biting immediately, promotion
not served stale, key rotation invalidating both sides, a record filed under the
wrong key never authenticating, unreadable records falling back instead of
raising, `sync()` dropping the cache, and legacy cluster mode not using it.

Disabling the invalidation helper fails exactly the three security-relevant
cases (revocation, promotion, rotation), so they are not passing vacuously.

`pytest tests/ -q`: **67 passed, 6 skipped**.

## History

This supersedes #31, which was reverted in #35 as an unauthorized automated
merge. This is a normal PR — please merge it yourself if and when you want it,
and note it is a different and stricter design: #31 only added the indexed
lookup, whereas this invalidates on every write instead of trusting the record
to stay fresh.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added faster API-key client lookups using a Redis-backed admission cache.
  * Cache entries are refreshed automatically when clients are created, updated, revoked, or synchronized.
  * Added support for safely handling unknown, expired, or invalid cached API keys.
  * Legacy cluster mode continues to use authoritative lookups.

* **Bug Fixes**
  * Prevented stale or corrupted cache records from affecting API-key authentication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->