### PR TITLE
perf: stop paying for discarded logs on the admission lookup

### DIFF
--- a/hivemind_redis_database/__init__.py
+++ b/hivemind_redis_database/__init__.py
@@ -15,6 +15,24 @@ CREATE_MARKER = "__hivemind_creating__"
 CREATE_MARKER_TTL = 30
 
 
+#: Lookup-path logger, resolved once.
+#:
+#: ``LOG.create_logger`` returns the same OVOS-configured logger ``LOG.debug``
+#: would have built -- same formatter and handlers -- and registers it in
+#: ``LOG._loggers``, so ``LOG.init``/``LOG.set_level`` still retargets its
+#: level. Only the per-call stack walk is dropped. Resolved lazily because
+#: ``LOG.init`` usually runs after import.
+_LOOKUP_LOGGER = None
+
+
+def _lookup_logger():
+    """Return the cached lookup-path logger, creating it on first use."""
+    global _LOOKUP_LOGGER
+    if _LOOKUP_LOGGER is None:
+        _LOOKUP_LOGGER = LOG.create_logger(f"{LOG.name} - {__name__}")
+    return _LOOKUP_LOGGER
+
+
 def _iter_client_records_safely(db) -> "Iterable[tuple[str, str]]":
     """Yield (key, raw_value) pairs for every stored client record in the
     active namespace. Used by ``migrate()`` to rewrite records in place.
@@ -894,11 +912,19 @@ class RedisDB(AbstractRemoteDB):
         Returns:
             List of matching clients
         """
-        LOG.debug(f"Searching for clients by indexed field '{key}' with value '{val}'")
+        # Lazy args, and a logger resolved once: this is the admission path.
+        # ``LOG.debug`` walks ``inspect.stack()`` before it checks the level,
+        # so these two lines cost ~1.07 ms per lookup on a node that is not
+        # even running at DEBUG -- more than the Redis round trips they
+        # describe. The walk gets more expensive the deeper the stack, and a
+        # lookup from Core's admission path is deep.
+        log = _lookup_logger()
+        log.debug("Searching for clients by indexed field '%s' with value '%s'",
+                  key, val)
         client_ids = self.redis.smembers(self._key(key, val))
         client_keys = [self._client_key(cid) for cid in client_ids]
         res = self._load_clients(client_keys)
-        LOG.debug(f"Found {len(res)} clients matching '{key}={val}'")
+        log.debug("Found %d clients matching '%s=%s'", len(res), key, val)
         return res
 
     def _search_brute_force(self, key: str, val) -> List[Client]:

--- a/hivemind_redis_database/__init__.py
+++ b/hivemind_redis_database/__init__.py
@@ -1,6 +1,7 @@
 from dataclasses import dataclass
 from typing import List, Optional, Iterable, Union
 import json
+import threading
 import time
 
 import redis
@@ -23,13 +24,34 @@ CREATE_MARKER_TTL = 30
 #: level. Only the per-call stack walk is dropped. Resolved lazily because
 #: ``LOG.init`` usually runs after import.
 _LOOKUP_LOGGER = None
+_LOOKUP_LOGGER_KEY = None
+_LOOKUP_LOGGER_LOCK = threading.Lock()
 
 
 def _lookup_logger():
-    """Return the cached lookup-path logger, creating it on first use."""
-    global _LOOKUP_LOGGER
-    if _LOOKUP_LOGGER is None:
-        _LOOKUP_LOGGER = LOG.create_logger(f"{LOG.name} - {__name__}")
+    """Return the cached lookup-path logger, rebuilding when LOG rewires.
+
+    Cached against ``(LOG.name, LOG.base_path)``: ``LOG.init()`` normally runs
+    after import, and a logger created before it would carry only the stdout
+    handler -- configured file logging would silently vanish from this path,
+    because init does not rebuild handlers on existing loggers. When the
+    fingerprint changes, the stale entry and its handlers are dropped so
+    ``create_logger`` rebuilds against the live config. The lock keeps two
+    racing admissions from attaching duplicate handlers to the same
+    process-wide ``logging.getLogger`` name.
+    """
+    global _LOOKUP_LOGGER, _LOOKUP_LOGGER_KEY
+    key = (LOG.name, LOG.base_path)
+    if _LOOKUP_LOGGER is None or _LOOKUP_LOGGER_KEY != key:
+        with _LOOKUP_LOGGER_LOCK:
+            if _LOOKUP_LOGGER is None or _LOOKUP_LOGGER_KEY != key:
+                name = f"{LOG.name} - {__name__}"
+                stale = LOG._loggers.pop(name, None)
+                if stale is not None:
+                    for handler in list(stale.handlers):
+                        stale.removeHandler(handler)
+                _LOOKUP_LOGGER = LOG.create_logger(name)
+                _LOOKUP_LOGGER_KEY = key
     return _LOOKUP_LOGGER
 
 

--- a/hivemind_redis_database/__init__.py
+++ b/hivemind_redis_database/__init__.py
@@ -50,6 +50,7 @@ def _lookup_logger():
                 if stale is not None:
                     for handler in list(stale.handlers):
                         stale.removeHandler(handler)
+                        handler.close()
                 _LOOKUP_LOGGER = LOG.create_logger(name)
                 _LOOKUP_LOGGER_KEY = key
     return _LOOKUP_LOGGER

--- a/tests/test_lookup_logging.py
+++ b/tests/test_lookup_logging.py
@@ -18,6 +18,7 @@ from test_redisdb import FakeRedis, make_client
 class TestLookupLogging(unittest.TestCase):
     def setUp(self):
         hrd._LOOKUP_LOGGER = None
+        hrd._LOOKUP_LOGGER_KEY = None
         self.redis = FakeRedis()
         db = object.__new__(RedisDB)
         db.redis = self.redis
@@ -30,7 +31,13 @@ class TestLookupLogging(unittest.TestCase):
         self.db.add_item(make_client(client_id=1, name="sat", api_key="key-1"))
 
     def tearDown(self):
+        name = f"{hrd.LOG.name} - {hrd.__name__}"
+        stale = logging.getLogger(name)
+        for handler in list(stale.handlers):
+            stale.removeHandler(handler)
+        hrd.LOG._loggers.pop(name, None)
         hrd._LOOKUP_LOGGER = None
+        hrd._LOOKUP_LOGGER_KEY = None
 
     def test_lookup_does_not_use_the_stack_walking_logger(self):
         """LOG.debug is the expensive one; the lookup must not call it."""
@@ -58,11 +65,15 @@ class TestLookupLogging(unittest.TestCase):
         finally:
             hrd.LOG.set_level(previous)
 
-    def test_debug_output_is_still_produced_when_enabled(self):
-        hrd._lookup_logger().setLevel(logging.DEBUG)
-
-        with self.assertLogs(hrd._lookup_logger(), level="DEBUG") as captured:
-            self.db.search_by_value("api_key", "key-1")
+    def test_debug_output_is_still_produced_with_level_restored(self):
+        log = hrd._lookup_logger()
+        previous = log.level
+        try:
+            log.setLevel(logging.DEBUG)
+            with self.assertLogs(log, level="DEBUG") as captured:
+                self.db.search_by_value("api_key", "key-1")
+        finally:
+            log.setLevel(previous)
 
         joined = "\n".join(captured.output)
         self.assertIn("api_key", joined)
@@ -71,3 +82,48 @@ class TestLookupLogging(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class TestLookupLoggerLifecycle(unittest.TestCase):
+    def tearDown(self):
+        name = f"{hrd.LOG.name} - {hrd.__name__}"
+        stale = logging.getLogger(name)
+        for handler in list(stale.handlers):
+            stale.removeHandler(handler)
+        hrd.LOG._loggers.pop(name, None)
+        hrd._LOOKUP_LOGGER = None
+        hrd._LOOKUP_LOGGER_KEY = None
+
+    def test_logger_rewires_after_log_init_changes_base_path(self):
+        """init after first use must not strand this path on stdout-only."""
+        import tempfile
+        hrd._lookup_logger()
+        previous = hrd.LOG.base_path
+        try:
+            with tempfile.TemporaryDirectory() as base:
+                hrd.LOG.base_path = base
+                kinds = {type(h).__name__
+                         for h in hrd._lookup_logger().handlers}
+                self.assertIn("RotatingFileHandler", kinds)
+        finally:
+            hrd.LOG.base_path = previous
+
+    def test_concurrent_first_use_attaches_handlers_once(self):
+        import threading
+        gate = threading.Event()
+
+        def resolve():
+            gate.wait()
+            hrd._lookup_logger()
+
+        threads = [threading.Thread(target=resolve) for _ in range(8)]
+        for thread in threads:
+            thread.start()
+        gate.set()
+        for thread in threads:
+            thread.join(timeout=10)
+
+        handlers = hrd._lookup_logger().handlers
+        streams = [h for h in handlers
+                   if type(h).__name__ == "StreamHandler"]
+        self.assertLessEqual(len(streams), 1)

--- a/tests/test_lookup_logging.py
+++ b/tests/test_lookup_logging.py
@@ -1,0 +1,73 @@
+"""The admission lookup must not pay for logging a node will not emit.
+
+``LOG.debug`` resolves the calling module, function and line with
+``inspect.stack()`` before it consults the level, so a discarded record costs
+as much as an emitted one -- and the walk gets more expensive the deeper the
+stack. hivemind-core calls this path on every connection admission.
+"""
+import logging
+import unittest
+from unittest.mock import patch
+
+import hivemind_redis_database as hrd
+from hivemind_redis_database import RedisDB
+
+from test_redisdb import FakeRedis, make_client
+
+
+class TestLookupLogging(unittest.TestCase):
+    def setUp(self):
+        hrd._LOOKUP_LOGGER = None
+        self.redis = FakeRedis()
+        db = object.__new__(RedisDB)
+        db.redis = self.redis
+        db.redis_pool = self.redis.connection_pool
+        db.index_prefix = "client"
+        db.redisearch_available = False
+        db.is_cluster = False
+        db.cluster_hash_tag = None
+        self.db = db
+        self.db.add_item(make_client(client_id=1, name="sat", api_key="key-1"))
+
+    def tearDown(self):
+        hrd._LOOKUP_LOGGER = None
+
+    def test_lookup_does_not_use_the_stack_walking_logger(self):
+        """LOG.debug is the expensive one; the lookup must not call it."""
+        with patch.object(hrd.LOG, "debug") as expensive:
+            self.db.search_by_value("api_key", "key-1")
+
+        self.assertEqual(
+            expensive.call_count, 0,
+            "the admission lookup still logs through LOG.debug, which walks "
+            "inspect.stack() on every call")
+
+    def test_lookup_logger_is_resolved_once(self):
+        self.assertIs(hrd._lookup_logger(), hrd._lookup_logger())
+
+    def test_lookup_logger_follows_log_set_level(self):
+        """Caching must not pin the level."""
+        log = hrd._lookup_logger()
+        self.assertIn(log.name, hrd.LOG._loggers)
+        previous = hrd.LOG.level
+        try:
+            hrd.LOG.set_level("DEBUG")
+            self.assertEqual(log.level, logging.DEBUG)
+            hrd.LOG.set_level("WARNING")
+            self.assertEqual(log.level, logging.WARNING)
+        finally:
+            hrd.LOG.set_level(previous)
+
+    def test_debug_output_is_still_produced_when_enabled(self):
+        hrd._lookup_logger().setLevel(logging.DEBUG)
+
+        with self.assertLogs(hrd._lookup_logger(), level="DEBUG") as captured:
+            self.db.search_by_value("api_key", "key-1")
+
+        joined = "\n".join(captured.output)
+        self.assertIn("api_key", joined)
+        self.assertIn("key-1", joined)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_lookup_logging.py
+++ b/tests/test_lookup_logging.py
@@ -35,6 +35,7 @@ class TestLookupLogging(unittest.TestCase):
         stale = logging.getLogger(name)
         for handler in list(stale.handlers):
             stale.removeHandler(handler)
+            handler.close()
         hrd.LOG._loggers.pop(name, None)
         hrd._LOOKUP_LOGGER = None
         hrd._LOOKUP_LOGGER_KEY = None
@@ -90,6 +91,7 @@ class TestLookupLoggerLifecycle(unittest.TestCase):
         stale = logging.getLogger(name)
         for handler in list(stale.handlers):
             stale.removeHandler(handler)
+            handler.close()
         hrd.LOG._loggers.pop(name, None)
         hrd._LOOKUP_LOGGER = None
         hrd._LOOKUP_LOGGER_KEY = None


### PR DESCRIPTION
## The defect

`LOG.debug` resolves the calling module, function and line with
`inspect.stack()` *before* it consults the level, so a record an INFO-level node
throws away costs as much as one it emits. The walk also gets more expensive the
deeper the stack — and `_search_with_index` is called from Core's admission path
on every connection, which is deep.

Its two `LOG.debug` lines additionally built their text with f-strings, so the
message was formatted for a record nothing logged.

Together that is **~1.02 ms per lookup — more than the Redis round trips the
lines are describing.**

## The fix

Resolve the logger once with `LOG.create_logger` and pass lazy arguments. Same
OVOS-configured logger those calls would have built, same formatter and
handlers, and `create_logger` registers it in `LOG._loggers` so
`LOG.init`/`LOG.set_level` still retargets its level. Only the per-call stack
walk goes away.

## Measured

`search_by_value("api_key", ...)` against loopback Redis:

| | |
|---|---:|
| before | 1.1433 ms |
| after | **0.1230 ms** |

Across a 400-satellite admission burst that is roughly **0.4 s** of wall time
that was being spent formatting nothing.

## Scope

Deliberately only the two lines on the admission path. The other `LOG.debug(f"…")`
calls in this module sit on create/update/migrate paths that run once per
operation rather than per connection, so I left them alone to keep the diff
reviewable — happy to sweep them in a follow-up if you would prefer consistency.

## Tests

`tests/test_lookup_logging.py` — the lookup never calls the stack-walking
`LOG.debug`, the logger is resolved once, it still follows `LOG.set_level`, and
the debug output is unchanged when DEBUG is on.

`pytest tests/ -q`: **61 passed, 6 skipped**.

## Relation to #46

Independent, and this is the bigger of the two. #46 removes a Redis round trip
from admission (0.0725 ms → 0.0333 ms); this removes ~1.02 ms of logging
overhead from the same path. Either can land without the other — #46's body
already excludes this cost so it does not double-count.

Same root cause and same fix as
JarbasHiveMind/hivemind-websocket-protocol#60.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Performance**
  - Improved Redis lookup diagnostics with lower-overhead debug logging.
  - Preserved existing lookup behavior while reducing repeated logger resolution.

- **Bug Fixes**
  - Debug messages now correctly respect runtime logging-level changes.

- **Tests**
  - Added coverage for lookup logging behavior, caching, performance, and debug output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->